### PR TITLE
Fix initial vector in eigen1 test

### DIFF
--- a/fulqrum/test/test_eigen.py
+++ b/fulqrum/test/test_eigen.py
@@ -62,7 +62,7 @@ def test_eigen1():
     # hashing only the first (`bitset.m_bits[0]`) bitset block
     S = Subspace([list(subspace_dict.keys())], use_all_bitset_blocks=False)
     Hsub = SubspaceHamiltonian(H, S)
-    evals, evecs = spla.eigsh(Hsub, k=2, which="SA",  v0=np.ones(len(S)))
+    evals, evecs = spla.eigsh(Hsub, k=2, which="SA", v0=np.ones(len(S)))
     assert np.allclose(ans_evals, evals)
     for kk in range(2):
         assert (

--- a/fulqrum/test/test_eigen.py
+++ b/fulqrum/test/test_eigen.py
@@ -47,11 +47,11 @@ def test_eigen1():
 
     subspace_dict = {bin(rr)[2:].zfill(H.width): 1 for rr in rows}
 
-    ans_evals, _ = spla.eigsh(B, k=2, which="SA")
+    ans_evals, _ = spla.eigsh(B, k=2, which="SA", v0=np.ones(B.shape[0]))
 
     S = Subspace([list(subspace_dict.keys())])
     Hsub = SubspaceHamiltonian(H, S)
-    evals, evecs = spla.eigsh(Hsub, k=2, which="SA")
+    evals, evecs = spla.eigsh(Hsub, k=2, which="SA", v0=np.ones(len(S)))
     assert np.allclose(ans_evals, evals)
     for kk in range(2):
         assert (
@@ -62,7 +62,7 @@ def test_eigen1():
     # hashing only the first (`bitset.m_bits[0]`) bitset block
     S = Subspace([list(subspace_dict.keys())], use_all_bitset_blocks=False)
     Hsub = SubspaceHamiltonian(H, S)
-    evals, evecs = spla.eigsh(Hsub, k=2, which="SA")
+    evals, evecs = spla.eigsh(Hsub, k=2, which="SA",  v0=np.ones(len(S)))
     assert np.allclose(ans_evals, evals)
     for kk in range(2):
         assert (


### PR DESCRIPTION
closes #16 

Fixes the initial vector in the tests to be the all-ones state.  I have run the tests multiple times now with no failures observed.  One cannot be sure this fixes things due to the stochastic nature of the error, but hopefully this does the trick