### PR TITLE
Add test for fast diagonal mode

### DIFF
--- a/fulqrum/core/linear_operator.py
+++ b/fulqrum/core/linear_operator.py
@@ -61,13 +61,16 @@ class SubspaceHamiltonian(LinearOperator):
         """
         return self.off_H.num_groups
 
-    def diagonal_vector(self):
+    def diagonal_vector(self, verbose=False, disable_fast_mode=False):
         """Return diagonal vector of Hamiltonian in subspace
 
+        Parameters:
+            verbose (bool): optional, verbose output, default=False
+            disable_fast_mode (bool): optional, disable fast computation for type=2 Hamiltonians, default=False
         Returns:
             ndarray: Complex vector for diagonal of Hamiltonian
         """
-        return self.spmv.diagonal_vector()
+        return self.spmv.diagonal_vector(verbose, disable_fast_mode)
 
     def minimum_diagonal_energy(self):
         """Return the minimum diagonal energy

--- a/fulqrum/core/spmv.pxd
+++ b/fulqrum/core/spmv.pxd
@@ -36,5 +36,6 @@ cdef class FulqrumSpMV:
     cdef public int is_real
     cdef unsigned int ladder_offset
     cdef vector[vector[width_t]] group_offdiag_inds
+    cdef bool _disable_fast_diag
 
     cpdef int compute_diag_vector(self)

--- a/fulqrum/core/spmv.pyx
+++ b/fulqrum/core/spmv.pyx
@@ -64,6 +64,7 @@ cdef class FulqrumSpMV():
         self.group_ptrs = group_ptrs
         self.group_ladder_ptrs = group_ladder_ptrs
         self.num_groups = group_ptrs.shape[0] - 1
+        self._disable_fast_diag = False
         if group_ptrs.shape[0] > 1:
             set_group_offdiag_indices(self.oper.terms, self.group_offdiag_inds,
                                       &self.group_ptrs[0], self.num_groups)
@@ -105,6 +106,8 @@ cdef class FulqrumSpMV():
         cdef pair[vector[pair[size_t, size_t]], size_t] ptrs_and_offset
         if self.diag_oper.type == 2:
             fast_diag = fast_diag_compatible(self.diag_oper)
+        if self._disable_fast_diag:
+            fast_diag = 0
         if fast_diag:
             diag_proj_index_sort(self.diag_oper)
             ptrs_and_offset =  projector_ptrs_and_offset(self.diag_oper)
@@ -139,8 +142,10 @@ cdef class FulqrumSpMV():
         self.init_diag = 1
         return 1
 
-
-    def diagonal_vector(self, int verbose=0):
+    def fast_diag_compatible(self):
+        return fast_diag_compatible(self.diag_oper)
+    
+    def diagonal_vector(self, int verbose=0, bool disable_fast_mode=False):
         """Diagonal vector of subspace Hamitlonian
 
         Returns:
@@ -153,7 +158,12 @@ cdef class FulqrumSpMV():
                 return np.zeros(self.subspace_dim, dtype=float)
             else:
                 return np.zeros(self.subspace_dim, dtype=complex)
+        cdef bool temp = self._disable_fast_diag
+        self._disable_fast_diag = disable_fast_mode
+        if verbose:
+            print("Diagonal fast mode enabled: ", (not self._disable_fast_diag))
         self.compute_diag_vector()
+        self._disable_fast_diag = temp
         if self.is_real:
             return np.asarray(self.real_diag_vec)
         if verbose:

--- a/fulqrum/test/test_diag.py
+++ b/fulqrum/test/test_diag.py
@@ -1,0 +1,33 @@
+# This code is a part of Fulqrum.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=no-name-in-module
+"""Test diagonal vector computation"""
+
+from pathlib import Path
+import numpy as np
+
+import fulqrum as fq
+from fulqrum.utils.io import json_to_dict
+
+
+def test_diag_fast_mode():
+    """Verify fast mode and default give same diagonal"""
+    op_path = Path(__file__).parent / "data/ch4_dimer_jw.json.xz"
+    op = fq.QubitOperator.from_json(op_path)
+
+    dist_path = Path(__file__).parent / "data/dimer_subspace.json.xz"
+    dist = json_to_dict(dist_path)
+    S = fq.Subspace([list(dist.keys())])
+    Hsub = fq.SubspaceHamiltonian(op, S)
+    diag1 = Hsub.diagonal_vector()  # This is fast mode
+    diag2 = Hsub.diagonal_vector(disable_fast_mode=True)  # This is regular mode
+    np.allclose(diag1, diag2, 1e-14)


### PR DESCRIPTION
This PR adds a test for fast diagonal mode that directly tests the validity of the calculation against the older pathway using the ch4_dimer.  This is a good example because there are non-zero diagonal terms with no projector ops as well.  

Functionality to directly disable the fast mode was added for testing purposes, but should otherwise not be exposed at some point.

This test was motivated by a branch that was hanging on this code, but is otherwise fine in other branches.