### PR TITLE
Fix bitset order in half strs mode

### DIFF
--- a/fulqrum/core/subspace.pyx
+++ b/fulqrum/core/subspace.pyx
@@ -146,8 +146,8 @@ cdef class Subspace():
             alpha_strs.sort()
             beta_strs.sort()
             iterator = map(
-                lambda ab: ab[1] + ab[0],
-                itertools.product(alpha_strs, beta_strs)
+                lambda ab: ab[0] + ab[1],
+                itertools.product(beta_strs, alpha_strs)
             )
             num_qubits = len(next(iter(alpha_strs))) + len(next(iter(beta_strs)))
             size = len(alpha_strs) * len(beta_strs)

--- a/fulqrum/test/test_subspace.py
+++ b/fulqrum/test/test_subspace.py
@@ -158,6 +158,25 @@ def test_bitset_dict():
     ]
 
 
+def test_half_strs_mode_globally_ascending():
+    """Test that half-string mode produces globally ascending insertion order.
+
+    Regression test for https://github.com/qiskit-community/fulqrum/issues/19.
+    Uses alpha and beta lists of different lengths (3 vs 2) so that any
+    incorrect product/concat ordering shows up. Earlier tests with identical
+    halves accidentally masked the bug.
+    """
+    alpha_half_strs = ["001", "010", "100"]
+    beta_half_strs = ["01", "10"]
+    S = Subspace([alpha_half_strs, beta_half_strs])
+
+    # Full bitstring is `beta + alpha`; iteration order must be ascending.
+    expected = ["01001", "01010", "01100", "10001", "10010", "10100"]
+    actual = [S.get_n_th_bitstring(i) for i in range(len(S))]
+    assert actual == expected
+    assert actual == sorted(actual)
+
+
 def test_bitset_init():
     """Test subspace init using bitsets"""
     A = {Bitset("01010"): 0, Bitset("01111"): 1, Bitset("11100"): 2, Bitset("00000"): 3}


### PR DESCRIPTION
As beta half occupies the higher bits in a full bitset, the order should have been beta outer x alpha inner in the Cartesian product space. Our test cases used identical alpha and beta halves, which masked the ordering issue. This PR fixes the beta and alpha ordering in half-strs mode so that the final Subspace has globally ascending bitsets. The PR also adds an explicit test with non-identical alpha and beta strs.