### PR TITLE
Fix Python crash with operator IO when throwing C++ exceptions

### DIFF
--- a/fulqrum/core/includes/base_header.pxi
+++ b/fulqrum/core/includes/base_header.pxi
@@ -71,8 +71,8 @@ cdef extern from "../src/base.hpp":
         vector[width_t] ladder_integers()
         vector[width_t] group_ladder_int_bit_lengths()
         vector[size_t] group_ladder_int_ptrs()
-        void to_json(string, bool) nogil
-        QubitOperator_t& from_json(string)
+        void to_json(string, bool) except +
+        QubitOperator_t from_json(string) except +
 
 
     ctypedef struct Subspace_t:
@@ -92,8 +92,8 @@ cdef extern from "../src/base.hpp":
         width_t width
         vector[FermionicTerm_t] terms
         size_t size()
-        void to_json(string, bool) nogil
-        FermionicOperator_t& from_json(string) nogil
+        void to_json(string, bool) except +
+        FermionicOperator_t from_json(string) except +
         FermionicOperator_t combine_repeat_indices() nogil
         QubitOperator_t extended_jw_transformation() nogil
 

--- a/fulqrum/core/src/io.hpp
+++ b/fulqrum/core/src/io.hpp
@@ -285,7 +285,7 @@ inline void json_to_operator(const std::string& filename, U& oper)
         {
             throw std::runtime_error("JSON operator type does not match input");
         }
-#pragma omp parallel for schedule(dynamic) if(num_terms > 1024)
+
         for(std::size_t kk = 0; kk < num_terms; kk++)
         {
             JsonTerm item = terms[kk];
@@ -303,7 +303,7 @@ inline void json_to_operator(const std::string& filename, U& oper)
         {
             throw std::runtime_error("JSON operator type does not match input");
         }
-#pragma omp parallel for schedule(dynamic) if(num_terms > 1024)
+
         for(std::size_t kk = 0; kk < num_terms; kk++)
         {
             JsonTerm item = terms[kk];


### PR DESCRIPTION
Errors caught in C++ space were not being raised into Python for operator IO causing kernel crashes.  This was because previously doing so, which is a Cython feature, made the unit tests unexpectedly fail.  The cause of this appears to be openmp usage in one of the functions.  Since that provided little improvement, this PR removes it, allowing for successful error propagation into Python and no more kernel crashes.