### PR TITLE
Allow for updating the subspace in a SubspaceHamiltonian

### DIFF
--- a/fulqrum/core/linear_operator.py
+++ b/fulqrum/core/linear_operator.py
@@ -17,6 +17,7 @@ from scipy.sparse.linalg import LinearOperator
 
 from .spmv import FulqrumSpMV
 from .csr import csr_matvec
+from .subspace import Subspace
 from ..exceptions import FulqrumError
 
 
@@ -29,12 +30,15 @@ class SubspaceHamiltonian(LinearOperator):
     # The subclass will complain if this is not here
     _matvec = None
 
-    def __init__(self, hamiltonian, subspace):
+    def __init__(self, hamiltonian, subspace=None):
         """A SciPy `LinearOperator` that represents a Hamiltonian restricted to the given
         subspace.
         """
-        if hamiltonian.width != subspace.width:
-            raise FulqrumError("Operator and subspace widths do not match")
+        if subspace:
+            if hamiltonian.width != subspace.width:
+                raise FulqrumError("Operator and subspace widths do not match")
+        else:
+            subspace = Subspace()
         self.diag_H, self.off_H = hamiltonian.split_diagonal()
         self.diag_H, self.const_energy = self.diag_H.remove_constant_terms()
         # if there are no off-diagonal terms then we pass a dummy empty array of len=1
@@ -69,6 +73,9 @@ class SubspaceHamiltonian(LinearOperator):
             int : Number of groups in operator
         """
         return self.off_H.num_groups
+    
+    def update_subspace(self, subspace):
+        self.spmv.update_subspace(subspace)
 
     def diagonal_vector(self, verbose=False, disable_fast_mode=False):
         """Return diagonal vector of Hamiltonian in subspace

--- a/fulqrum/core/linear_operator.py
+++ b/fulqrum/core/linear_operator.py
@@ -73,7 +73,7 @@ class SubspaceHamiltonian(LinearOperator):
             int : Number of groups in operator
         """
         return self.off_H.num_groups
-    
+
     def update_subspace(self, subspace):
         self.spmv.update_subspace(subspace)
 

--- a/fulqrum/core/spmv.pxd
+++ b/fulqrum/core/spmv.pxd
@@ -41,3 +41,4 @@ cdef class FulqrumSpMV:
     cdef bool _disable_fast_diag
 
     cpdef int compute_diag_vector(self)
+    cpdef void update_subspace(self, Subspace)

--- a/fulqrum/core/spmv.pyx
+++ b/fulqrum/core/spmv.pyx
@@ -45,6 +45,13 @@ include "includes/csrlike_builder_header.pxi"
 include "includes/csrlike_builder2_header.pxi"
 
 
+cdef width_check(width_t ham_width, width_t sub_width):
+    """Validate that Hamiltonian width is the same as the subspace width
+    """
+    if ham_width != sub_width:
+        raise FulqrumError(f"Hamiltonian width ({ham_width}) does not match subspace width ({sub_width})")
+
+
 cdef class FulqrumSpMV():
     def __cinit__(self, QubitOperator diag_hamiltonian,
                   double const_energy,
@@ -103,11 +110,20 @@ cdef class FulqrumSpMV():
         out += f"is_real={self.is_real}>"
         return out
 
+    cpdef void update_subspace(self, Subspace subspace):
+        """Update the subspace attached to the object
+        """
+        self.subspace = subspace
+        self.subspace_dim = self.subspace.size()
+        self.init_diag = 0
+        self.real_diag_vec = np.empty(shape=(1,), dtype=float)
+        self.complex_diag_vec = np.empty(shape=(1,), dtype=complex)
 
     @cython.boundscheck(False)
     cpdef int compute_diag_vector(self):
         if self.init_diag:
             return 0
+        width_check(self.width, self.subspace.width)    
         cdef bool fast_diag = self.fast_diag
         if self._disable_fast_diag:
             fast_diag = 0
@@ -147,6 +163,7 @@ cdef class FulqrumSpMV():
         Returns:
             ndarray: Array of complex numbers representing diagonal
         """
+        width_check(self.width, self.subspace.width)
         if verbose:
             st = time.perf_counter()
         if not self.has_nonzero_diag:

--- a/fulqrum/core/subspace.pxd
+++ b/fulqrum/core/subspace.pxd
@@ -16,3 +16,4 @@ include "includes/base_header.pxi"
 
 cdef class Subspace():
     cdef Subspace_t subspace
+

--- a/fulqrum/core/subspace.pyx
+++ b/fulqrum/core/subspace.pyx
@@ -90,7 +90,7 @@ cdef class Subspace():
 
     """
     @cython.boundscheck(False)
-    def __cinit__(self, object subspace_strs, int reserve_multiplier=2, bool use_all_bitset_blocks=True):
+    def __cinit__(self, object subspace_strs=None, int reserve_multiplier=2, bool use_all_bitset_blocks=True):
         """
         args:
             subspace_strs: Input bitstrings as either length-1 or length-2 tuple
@@ -130,6 +130,8 @@ cdef class Subspace():
                 full hashing usually leads to fewer collisions during Hash table look-up.
                 Default: `True`.
         """
+        if not subspace_strs:
+            return
         cdef int input_bitsets = 0
         if len(subspace_strs) == 0:
             return

--- a/fulqrum/test/test_subspacehamiltonian.py
+++ b/fulqrum/test/test_subspacehamiltonian.py
@@ -1,0 +1,47 @@
+# This code is a part of Fulqrum.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=no-name-in-module
+import pytest
+from pathlib import Path
+
+import numpy as np
+import fulqrum as fq
+from fulqrum.exceptions import FulqrumError
+
+
+_path = Path(__file__).parent / "data/lih.json"
+FOP = fq.FermionicOperator.from_json(_path)
+OP = FOP.extended_jw_transformation()
+
+
+def test_subspacehamiltonian_different_widths():
+    """Hamiltonian and subspace with different widths raises"""
+    S = fq.Subspace()
+    Hsub = fq.SubspaceHamiltonian(OP, S)
+    with pytest.raises(FulqrumError) as err:
+        Hsub.diagonal_vector()
+
+
+def test_subspacehamiltonian_update_subspace():
+    """Test that updating a subspace works"""
+    S = fq.Subspace()
+    S2 = fq.Subspace([["1" * 12]])
+    Hsub = fq.SubspaceHamiltonian(OP, S)
+    Hsub.update_subspace(S2)
+    diag = Hsub.diagonal_vector()
+    assert np.allclose(diag, np.array([1.77959097]))
+
+
+def test_subspacehamiltonian_init_no_subspace():
+    """Can initialize a SubspaceHamiltonian with no subspace"""
+    Hsub = fq.SubspaceHamiltonian(OP)
+    assert Hsub.spmv.subspace_dim == 0

--- a/fulqrum/test/test_subspacehamiltonian.py
+++ b/fulqrum/test/test_subspacehamiltonian.py
@@ -27,7 +27,7 @@ def test_subspacehamiltonian_different_widths():
     """Hamiltonian and subspace with different widths raises"""
     S = fq.Subspace()
     Hsub = fq.SubspaceHamiltonian(OP, S)
-    with pytest.raises(FulqrumError) as err:
+    with pytest.raises(FulqrumError) as _:
         Hsub.diagonal_vector()
 
 


### PR DESCRIPTION
closes #44

Allows for updating the `Subspace` attached to a `SubspaceHamiltonian` so that all of the initialization of the Hamiltonian objects can be bypassed when using a new subspace.  This is accomplished using the `SubspaceHamiltonian.update_subspace()` method.  Also allows for initialization of  `SubspaceHamiltonian` without a `Subspace` object.  Safety checks and unit tests have been added.