### PR TITLE
RAMPS takes SubspaceHamiltonian

### DIFF
--- a/fulqrum/ramps/open.pyx
+++ b/fulqrum/ramps/open.pyx
@@ -17,6 +17,7 @@ from ..core.bitset cimport Bitset
 from ..core.bitset cimport bitset_t
 from ..core.linear_operator import SubspaceHamiltonian
 from ..core.spmv cimport FulqrumSpMV
+from ..exceptions import FulqrumError
 
 include "includes/open_header.pxi"
 
@@ -24,13 +25,13 @@ import numpy as np
 
 
 
-def ramps_open(QubitOperator H, Subspace target_subspace, double target_energy,
+def ramps_open(object Hsub, Subspace target_subspace, double target_energy,
                unsigned int max_recursion=2, double tol=1e-12):
     """RAMPS restricted to an existing subspace when targeting a single bit-string
     and associated energy.
 
     Parameters:
-        H (QubitOperator): Hamiltonian
+        Hsub (SubspaceHamiltonian): Hamiltonian
         target_subspace (Subspace): Target subspace to expand around
         target_energy (double): Target energy from target subspace
         max_recursion (int): Optional, maximum number of recursions to perform, default=2
@@ -39,8 +40,9 @@ def ramps_open(QubitOperator H, Subspace target_subspace, double target_energy,
     Returns:
         Subspace: RAMPS refined subspace
     """
+    if not isinstance(Hsub, SubspaceHamiltonian):
+        raise FulqrumError("Input Hamiltonian must be a SubspaceHamiltonian object")
     cdef Subspace out = target_subspace.copy()
-    Hsub = SubspaceHamiltonian(H, target_subspace)
     cdef FulqrumSpMV spmv = Hsub.spmv
     cdef double energy = open_ramps(spmv.oper,
                                     out.subspace.bitstrings,

--- a/fulqrum/ramps/simple.pyx
+++ b/fulqrum/ramps/simple.pyx
@@ -17,6 +17,7 @@ from ..core.bitset cimport Bitset
 from ..core.bitset cimport bitset_t
 from ..core.linear_operator import SubspaceHamiltonian
 from ..core.spmv cimport FulqrumSpMV
+from ..exceptions import FulqrumError
 
 include "includes/simple_header.pxi"
 
@@ -24,13 +25,13 @@ import numpy as np
 
 
 
-def ramps_restricted_simple(QubitOperator H, Subspace target_subspace, double target_energy,
+def ramps_restricted_simple(object Hsub, Subspace target_subspace, double target_energy,
                             Subspace restricted_subspace, unsigned int max_recursion=2, double tol=1e-12):
     """RAMPS restricted to an existing subspace when targeting a single bit-string
     and associated energy.
 
     Parameters:
-        H (QubitOperator): Hamiltonian
+        Hsub (SubspaceHamiltonian): Hamiltonian
         target_subspace (Subspace): Target subspace to expand around
         target_energy (double): Target energy from target subspace
         restricted_subspace (Subspace): Subspace to restrict search in
@@ -40,8 +41,9 @@ def ramps_restricted_simple(QubitOperator H, Subspace target_subspace, double ta
     Returns:
         Subspace: RAMPS refined subspace
     """
+    if not isinstance(Hsub, SubspaceHamiltonian):
+        raise FulqrumError("Input Hamiltonian must be a SubspaceHamiltonian object")
     cdef Subspace out = target_subspace.copy()
-    Hsub = SubspaceHamiltonian(H, target_subspace)
     cdef FulqrumSpMV spmv = Hsub.spmv
     cdef double energy = simple_restricted(spmv.oper,
                                            restricted_subspace.subspace.bitstrings,

--- a/fulqrum/test/test_ramps.py
+++ b/fulqrum/test/test_ramps.py
@@ -41,7 +41,7 @@ def test_ramps_simple_refine_subspace_dim():
 
     target_subspace = Subspace([[S[min_idx].to_string()]])
     target_energy = diag[min_idx]
-    out = ramps_restricted_simple(NEW_OP, target_subspace, target_energy, S)
+    out = ramps_restricted_simple(HSUB, target_subspace, target_energy, S)
     assert out.size() == 69
 
 
@@ -52,7 +52,7 @@ def test_ramps_simple_refine_accuracy():
 
     target_subspace = Subspace([[S[min_idx].to_string()]])
     target_energy = diag[min_idx]
-    out = ramps_restricted_simple(NEW_OP, target_subspace, target_energy, S)
+    out = ramps_restricted_simple(HSUB, target_subspace, target_energy, S)
 
     Hsub_small = SubspaceHamiltonian(NEW_OP, out)
     approx_energy = spla.eigsh(
@@ -69,7 +69,7 @@ def test_ramps_open_lih():
 
     target_subspace = Subspace([[S[min_idx].to_string()]])
     target_energy = diag[min_idx]
-    out = ramps_open(NEW_OP, target_subspace, target_energy)
+    out = ramps_open(HSUB, target_subspace, target_energy)
 
     assert out.size() == 69  # same as above
 


### PR DESCRIPTION
Modifies the RAMPS signatures to take a `SubspaceHamiltonian` instead of a `QubitOperator` so that we do not have to waste time manipulating the operator inside the RAMPS routines.