### PR TITLE
Set type of QubitOperator when loading from JSON

### DIFF
--- a/fulqrum/core/fermi_operator.pyx
+++ b/fulqrum/core/fermi_operator.pyx
@@ -23,8 +23,7 @@ from .qubit_operator cimport QubitOperator
 from ..utils.io import dict_to_json, json_to_dict
 from ..exceptions import FulqrumError
 
-import orjson
-import lzma
+
 from pathlib import Path
 import warnings
 import numpy as np

--- a/fulqrum/core/qubit_operator.pyx
+++ b/fulqrum/core/qubit_operator.pyx
@@ -34,8 +34,6 @@ from .constants import np_width_t
 from collections.abc import Iterable
 from pathlib import Path
 import numbers
-import orjson
-import lzma
 import numpy as np
 cimport numpy as np
 

--- a/fulqrum/core/src/io.hpp
+++ b/fulqrum/core/src/io.hpp
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -282,6 +283,9 @@ inline void json_to_operator(const std::string& filename, U& oper)
     auto terms = Doc["terms"];
     std::size_t num_terms = terms.size();
     oper.terms.resize(num_terms);
+    std::vector<std::string> version_split = split_string(Doc["format-version"], ".");
+    int major_version = std::stoi(version_split[0]);
+    int minor_version = std::stoi(version_split[1]);
 
 
     if constexpr(std::is_same_v<U, QubitOperator>)
@@ -302,9 +306,15 @@ inline void json_to_operator(const std::string& filename, U& oper)
             oper.terms[kk] = term;
         }
          // look to see if method-type exists, should in V1.1
-        if(Doc.contains("method-type"))
+        if(major_version >=1 && minor_version >= 1)
         {
-            oper.type = Doc["method-type"];
+            if(Doc.contains("method-type"))
+            {
+                oper.type = Doc["method-type"];
+            }
+            else{
+                throw std::runtime_error("JSON format 1.1+ should have a 'method-type' key");
+            }
         }
     }
     else if constexpr(std::is_same_v<U, FermionicOperator>)

--- a/fulqrum/core/src/io.hpp
+++ b/fulqrum/core/src/io.hpp
@@ -118,9 +118,12 @@ inline void operator_to_json(const T& oper, const std::string& filename, bool ov
 {
     std::string op_type;
     std::string ending;
+    // set the oper.type to json
+    int method_type = 2;
     if constexpr(std::is_same_v<T, QubitOperator>)
     {
         op_type = "qubit";
+        method_type = oper.type;
     }
     else if constexpr(std::is_same_v<T, FermionicOperator>)
     {
@@ -154,9 +157,10 @@ inline void operator_to_json(const T& oper, const std::string& filename, bool ov
         terms.push_back(json_term);
     }
 
-    json Doc{{"format-version", "1.0"},
-             {"fulqrum-version", "0.1.0"},
+    json Doc{{"format-version", "1.1"},
+             {"fulqrum-version", "0.2.0"},
              {"operator-type", op_type},
+             {"method-type", method_type},
              {"width", oper.width},
              {"terms", terms}};
 
@@ -278,6 +282,7 @@ inline void json_to_operator(const std::string& filename, U& oper)
     std::size_t num_terms = terms.size();
     oper.terms.resize(num_terms);
 
+
     if constexpr(std::is_same_v<U, QubitOperator>)
     {
         if(Doc["operator-type"] != "qubit")
@@ -294,6 +299,14 @@ inline void json_to_operator(const std::string& filename, U& oper)
             set_offdiag_weight_and_phase(term);
             set_extended_flag(term);
             oper.terms[kk] = term;
+        }
+         // look to see if method-type exists, should in V1.1
+        if(Doc.contains("method-type"))
+        {
+            if(Doc["operator-type"] != "qubit")
+            {
+                oper.type = Doc["method-type"];
+            }
         }
     }
     else if constexpr(std::is_same_v<U, FermionicOperator>)

--- a/fulqrum/core/src/io.hpp
+++ b/fulqrum/core/src/io.hpp
@@ -24,6 +24,7 @@
 
 #include "./external/json.hpp"
 #include "base.hpp"
+#include "version.hpp"
 
 using json = nlohmann::json;
 typedef std::complex<double> complex;
@@ -157,8 +158,8 @@ inline void operator_to_json(const T& oper, const std::string& filename, bool ov
         terms.push_back(json_term);
     }
 
-    json Doc{{"format-version", "1.1"},
-             {"fulqrum-version", "0.2.0"},
+    json Doc{{"format-version", JSON_VERSION},
+             {"fulqrum-version", FULQRUM_VERSION},
              {"operator-type", op_type},
              {"method-type", method_type},
              {"width", oper.width},
@@ -303,10 +304,7 @@ inline void json_to_operator(const std::string& filename, U& oper)
          // look to see if method-type exists, should in V1.1
         if(Doc.contains("method-type"))
         {
-            if(Doc["operator-type"] != "qubit")
-            {
-                oper.type = Doc["method-type"];
-            }
+            oper.type = Doc["method-type"];
         }
     }
     else if constexpr(std::is_same_v<U, FermionicOperator>)

--- a/fulqrum/core/src/version.hpp
+++ b/fulqrum/core/src/version.hpp
@@ -1,0 +1,17 @@
+/**
+ * This code is part of Fulqrum.
+ *
+ * (C) Copyright IBM 2024.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+#pragma once
+
+#define FULQRUM_VERSION "0.2.1"
+#define JSON_VERSION "1.1"

--- a/fulqrum/test/test_operator_io.py
+++ b/fulqrum/test/test_operator_io.py
@@ -75,3 +75,15 @@ def test_qubit_xz():
         os.remove("lih_op.json")
     except FileNotFoundError:
         pass
+
+
+def test_fermionic_to_qubit_method_in_json():
+    """Test round-trip of fermionic to json"""
+    OP.to_json("lih_jw.json", overwrite=True)
+    assert OP.type == 2
+    new_op = fq.QubitOperator.from_json("lih_jw.json")
+    assert new_op.type == 2
+    try:
+        os.remove("lih_jw.json")
+    except FileNotFoundError:
+        pass

--- a/fulqrum/test/test_subspacehamiltonian.py
+++ b/fulqrum/test/test_subspacehamiltonian.py
@@ -17,7 +17,6 @@ import numpy as np
 import fulqrum as fq
 from fulqrum.exceptions import FulqrumError
 
-
 _path = Path(__file__).parent / "data/lih.json"
 FOP = fq.FermionicOperator.from_json(_path)
 OP = FOP.extended_jw_transformation()


### PR DESCRIPTION
When originally making the IO code I did not think of people saving type=2 operators in as `QubitOperator` types in JSON.  This meant that the type information was being lost, leading to poor performance.  This fixes that by adding type information to the JSON file, and using that when importing.  This bumps the JSON version `1.0` -> `1.1`.

I am kicking the can down the road here for unified Python and C++ versioning (which is needed in the JSON files).  I will do that in a follow up PR.