### PR TITLE
Fix MANIFEST.in for proper sdist build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,12 @@
 include LICENSE.txt
 include README.md
 include requirements.txt
-recursive-include fulqrum/core/includes *.pxi
-recursive-include fulqrum/core *.pxd
+recursive-include fulqrum *.pxi
+recursive-include fulqrum *.pxd
+recursive-include fulqrum *.pyx
 recursive-include fulqrum/core/src *.hpp
 recursive-include fulqrum/test/data *.json
 recursive-include fulqrum/include *.hpp
 recursive-include fulqrum/core/src/external *.hpp
 recursive-include fulqrum/core/src/external *.h
+recursive-include qiskit-addon-sqd-hpc/include *.hpp


### PR DESCRIPTION
This adds some necessary files to `MANIFEST.in` so that the sdist contains all necessary files.  Prior to this, the command sequence `pip install build; python -m build` would fail.

It would be nice to test `python -m build` on every commit to main in a follow-up to this, so that this regression does not creep in again. This is how the [example on the python packaging
site](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) works, and it is also the approach we use in the `release.yml` file within the Qiskit addons.