### PR TITLE
Fix open ramps docstrings

### DIFF
--- a/fulqrum/__init__.py
+++ b/fulqrum/__init__.py
@@ -12,7 +12,7 @@
 
 """Fulqrum"""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 from .core import (

--- a/fulqrum/ramps/open.pyx
+++ b/fulqrum/ramps/open.pyx
@@ -26,19 +26,21 @@ import numpy as np
 
 
 def ramps_open(object Hsub, Subspace target_subspace, double target_energy,
-               unsigned int max_recursion=2, double tol=1e-12):
-    """RAMPS restricted to an existing subspace when targeting a single bit-string
-    and associated energy.
+               unsigned int max_recursion=1, double tol=1e-12):
+    """Unrestricted RAMPS around the input target subspace.
+
+    The resultant subspace will be the target subspace with addtional bit-strings
+    added that perturbatively affect the energy more than the tolereance value
 
     Parameters:
         Hsub (SubspaceHamiltonian): Hamiltonian
         target_subspace (Subspace): Target subspace to expand around
         target_energy (double): Target energy from target subspace
-        max_recursion (int): Optional, maximum number of recursions to perform, default=2
+        max_recursion (int): Optional, maximum number of recursions to perform, default=1
         tol (double): Optional, tolerance value for truncation, default=1e-12
 
     Returns:
-        Subspace: RAMPS refined subspace
+        Subspace: RAMPS constructed subspace
     """
     if not isinstance(Hsub, SubspaceHamiltonian):
         raise FulqrumError("Input Hamiltonian must be a SubspaceHamiltonian object")

--- a/fulqrum/ramps/open.pyx
+++ b/fulqrum/ramps/open.pyx
@@ -30,7 +30,7 @@ def ramps_open(object Hsub, Subspace target_subspace, double target_energy,
     """Unrestricted RAMPS around the input target subspace.
 
     The resultant subspace will be the target subspace with addtional bit-strings
-    added that perturbatively affect the energy more than the tolereance value
+    added that perturbatively affect the energy more than the tolerance value
 
     Parameters:
         Hsub (SubspaceHamiltonian): Hamiltonian

--- a/fulqrum/test/test_ramps.py
+++ b/fulqrum/test/test_ramps.py
@@ -69,7 +69,7 @@ def test_ramps_open_lih():
 
     target_subspace = Subspace([[S[min_idx].to_string()]])
     target_energy = diag[min_idx]
-    out = ramps_open(HSUB, target_subspace, target_energy)
+    out = ramps_open(HSUB, target_subspace, target_energy, max_recursion=2)
 
     assert out.size() == 69  # same as above
 


### PR DESCRIPTION
Fixes the incorrect information in the open RAMPS docstring.  Also takes the opportunity to change the default number of recursions to 1 since that is more useful in practice.  As such, also bumps the version

closes #65 