### PR TITLE
Faster ramps and _matvec fix

### DIFF
--- a/fulqrum/__init__.py
+++ b/fulqrum/__init__.py
@@ -12,7 +12,7 @@
 
 """Fulqrum"""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 
 from .core import (

--- a/fulqrum/core/linear_operator.py
+++ b/fulqrum/core/linear_operator.py
@@ -159,6 +159,8 @@ class SubspaceHamiltonian(LinearOperator):
             x = x.view().reshape(
                 x.shape[0],
             )
+        # The Cython SpMV requires a C-contiguous buffer; no-op if x already is.
+        x = np.ascontiguousarray(x)
         out = self.spmv.matvec(x)
         if col_vec:
             out = out.view().reshape(x.shape[0], 1)
@@ -207,6 +209,9 @@ class CSRLinearOperator(LinearOperator):
         self.matrix = matrix
         self.is_real = is_real
         super().__init__(shape=matrix.shape, dtype=float if self.is_real else complex)
+        # scipy >= 1.18 can throw error without it.
+        # See: https://github.com/qiskit-community/fulqrum/issues/67
+        self._matvec = self.matvec
 
     @property
     def nnz(self):
@@ -241,6 +246,8 @@ class CSRLinearOperator(LinearOperator):
             x = x.view().reshape(
                 x.shape[0],
             )
+        # The Cython SpMV requires a C-contiguous buffer; no-op if x already is.
+        x = np.ascontiguousarray(x)
         out = np.zeros_like(x, dtype=float if self.is_real else complex)
         csr_matvec(
             self.matrix.indptr,
@@ -267,6 +274,7 @@ class CSRLikeLinearOperator(LinearOperator):
         self.csrlike = csrlike
         self.is_real = csrlike.is_real
         super().__init__(shape=csrlike.shape, dtype=float if self.is_real else complex)
+        self._matvec = self.matvec
 
     def to_csr_array(self, verbose=False):
         return self.csrlike.to_csr_array(verbose)
@@ -312,6 +320,8 @@ class CSRLikeLinearOperator(LinearOperator):
             x = x.view().reshape(
                 x.shape[0],
             )
+        # The Cython SpMV requires a C-contiguous buffer; no-op if x already is.
+        x = np.ascontiguousarray(x)
         out = self.csrlike.matvec(x)
         if col_vec:
             out = out.view().reshape(x.shape[0], 1)

--- a/fulqrum/core/src/diag.hpp
+++ b/fulqrum/core/src/diag.hpp
@@ -12,6 +12,7 @@
  * that they have been altered from the originals.
  */
 #pragma once
+#include <cassert>
 #include <complex>
 #include <cstddef>
 #include <cstdlib>
@@ -260,6 +261,152 @@ inline void single_bitstring_diagonal_fast(const boost::dynamic_bitset<size_t>& 
                 row, row, term->indices, term->values, term->coeff, term->real_phase, weight, val);
         }
     }
+}
+
+/**
+ * Incremental fast-diagonal energy col bitset. E(row) must be known.
+ *
+ * row and col bitsets only differs on offdiag_grp_inds positions (flip_inds here).
+ * When we know the diagonal energy for a row bitset, E(row), we can incrementally
+ * correct the E(row) to compute the E(col).
+ * 
+ * single_bitstring_diagonal_fast uses two nested loops over set bits indices (= num
+ * of electrons) of a bitset, which takes nelecs * (nelecs + 1) / 2 iterations. 
+ * Consider a row bitset with set bits at [0, 2, 3, 5] (nelecs = 4). E(row) iterates
+ * over or has contribution from following 10 (set_bits[ll], set_bits[mm]) pairs:
+ * (0, 0), (0, 2), (0, 3), (0, 5), (2, 2), (2, 3), (2, 5), (3, 3), (3, 5), and (5, 5).
+ * 
+ * Now, consider a group with flip_inds [2, 4]. The corresponding col for this group
+ * and row will have set bits at [0, 3, 4, 5] ("1" bit at row pos 2 flips to "0", and
+ * "0" bit at row pos 4 flips to "1"). E(col) needs contribution from following 10
+ * pairs:
+ * (0, 0), (0, 3), (0, 4), (0, 5), (3, 3), (3, 4), (3, 5), (4, 4), (4, 5), and (5, 5).
+ * 
+ * If we inspect pairs from E(row) and E(col), we can find three buckets of pairs:
+ * A. Common in both row and col: (0, 0), (0, 3), (0, 5), (3, 3), (3, 5), and (5, 5).
+ * B. In col, but not in row: (0, 4), (3, 4), (4, 4), (4, 5)
+ * C. Not in col, but in row: (0, 2), (2, 2), (2, 3), (2, 5)
+ * 
+ * To compute E(col) by editing E(row), we need to subtract contributions from pairs
+ * that are not in col but in row (Bucket # C), and add from pairs that are in col but not in row (Bucket # B).
+ * 
+ * E(col) = E(row) + delta
+ *        = E(row) + Bucket B - Bucket C
+ * 
+ * When we already know E(row), we just need to compute delta to find E(col).
+ * Incremental delta needs 4 pairs in Bucket B + 4 pairs in Bucket C = 8 pairs
+ * instead of full 10 pairs from scratch to get E(col).
+ * 
+ * In general, incremental delta needs nflips * nelecs steps instead of
+ * (nelecs * (nelecs + 1)) / 2 steps, which can pay more dividends when
+ * nelecs is large.
+ * For example, Fe4S4 has 54 electrons requiring (54 * 55) / 2 = 1485 steps per det.
+ * With incremental logic that drops to 2 * 54 = 108 for single excitation groups
+ * and 4 * 54 + 2 = 218 for double excitation groups.
+ *
+ * `row_occ` must be set_bit_indices(row) (passed in so it can be reused across all
+ * connected cols of a row).`flip_inds` need not be
+ * sorted; nflip must be <=4 (2 or 4).
+ */
+template <typename T>
+inline T single_bitstring_diagonal_delta_fast(const boost::dynamic_bitset<size_t>& row,
+                                              const boost::dynamic_bitset<size_t>& col,
+                                              const std::vector<width_t>& row_occ,
+                                              const std::vector<OperatorTerm>& diag_terms,
+                                              const std::vector<std::size_t>& row_ptrs,
+                                              const width_t* flip_inds,
+                                              const unsigned int nflip,
+                                              const T e_row)
+{
+    auto g = [&](width_t a, width_t b, const boost::dynamic_bitset<size_t>& det) -> T {
+        const width_t lo = a < b ? a : b;
+        const width_t hi = a < b ? b : a;
+        const OperatorTerm* term = &diag_terms[row_ptrs[lo] + (hi - lo)];
+        T v = 0;
+        accum_element(det,
+                      det,
+                      term->indices,
+                      term->values,
+                      term->coeff,
+                      term->real_phase,
+                      term->indices.size(),
+                      v);
+        return v;
+    };
+
+    // Split flips into positions added (0->1) and removed (1->0) going row -> col.
+    // Type-2 off-diagonal groups are single (nflip==2) or double (nflip==4)
+    // excitations, so na + nr == nflip <= 4 and each buffer holds at most 4.
+    assert(nflip <= 4);
+    width_t added[4];
+    width_t removed[4];
+    unsigned int na = 0, nr = 0;
+    for(unsigned int f = 0; f < nflip; f++)
+    {
+        const width_t p = flip_inds[f];
+        if(row[p])
+        {
+            removed[nr++] = p;
+        }
+        else
+        {
+            added[na++] = p;
+        }
+    }
+
+    auto is_removed = [&](width_t y) {
+        for(unsigned int i = 0; i < nr; i++)
+        {
+            if(removed[i] == y)
+            {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    T delta = 0;
+    for(unsigned int i = 0; i < na; i++)
+    {
+        const width_t a = added[i];
+        for(std::size_t t = 0; t < row_occ.size(); t++)
+        {
+            const width_t y = row_occ[t];
+            if(!is_removed(y))
+            {
+                delta += g(a, y, col);
+            }
+        }
+        for(unsigned int j = 0; j < na; j++) // added-added (incl self g(a,a))
+        {
+            delta += g(a, added[j], col);
+        }
+    }
+    for(unsigned int i = 0; i < na; i++) // undo double-counted added-added pairs
+    {
+        for(unsigned int j = i + 1; j < na; j++)
+        {
+            delta -= g(added[i], added[j], col);
+        }
+    }
+
+    for(unsigned int i = 0; i < nr; i++)
+    {
+        const width_t r = removed[i];
+        for(std::size_t t = 0; t < row_occ.size(); t++)
+        {
+            delta -= g(r, row_occ[t], row);
+        }
+    }
+    for(unsigned int i = 0; i < nr; i++) // undo double-counted removed-removed pairs
+    {
+        for(unsigned int j = i + 1; j < nr; j++)
+        {
+            delta += g(removed[i], removed[j], row);
+        }
+    }
+
+    return e_row + delta;
 }
 
 /**

--- a/fulqrum/core/src/version.hpp
+++ b/fulqrum/core/src/version.hpp
@@ -13,5 +13,5 @@
  */
 #pragma once
 
-#define FULQRUM_VERSION "0.2.1"
+#define FULQRUM_VERSION "0.2.3"
 #define JSON_VERSION "1.1"

--- a/fulqrum/ramps/src/open.hpp
+++ b/fulqrum/ramps/src/open.hpp
@@ -43,6 +43,8 @@ double open_ramps(const QubitOperator& oper,
     std::size_t recur, kk, current;
     // do stuff if the diagonal can be evaluated quickly
     bool do_fast_diag = fast_diag_compatible(diag_oper);
+    // alpha (spin-up) sector is the lower half of the bitset, beta the upper half
+    const width_t half_width = width / 2;
     std::vector<std::size_t> row_ptrs;
     if(do_fast_diag)
     {
@@ -82,7 +84,6 @@ double open_ramps(const QubitOperator& oper,
     std::size_t num_inserted_bitsets = 1;
     std::complex<double> val = 0;
     unsigned int row_int;
-    int do_col_search;
 
     struct Candidate
     {
@@ -101,18 +102,17 @@ double open_ramps(const QubitOperator& oper,
         std::vector<std::vector<Candidate>> pending_candidates(current_rows.size());
 // Loop over all rows in the current set
 #pragma omp parallel for private(col_vec,                                                          \
-                                     group_inds,                                                   \
-                                     out_col_ptr,                                                  \
-                                     idx,                                                          \
-                                     group,                                                        \
-                                     group_int_start,                                              \
-                                     group_int_stop,                                               \
-                                     val,                                                          \
-                                     row_int,                                                      \
-                                     do_col_search,                                                \
-                                     col_energy,                                                   \
-                                     energy_amp,                                                   \
-                                     term) schedule(dynamic)
+                                 group_inds,                                                       \
+                                 out_col_ptr,                                                      \
+                                 idx,                                                              \
+                                 group,                                                            \
+                                 group_int_start,                                                  \
+                                 group_int_stop,                                                   \
+                                 val,                                                              \
+                                 row_int,                                                          \
+                                 col_energy,                                                       \
+                                 energy_amp,                                                       \
+                                 term) schedule(dynamic)
         for(kk = 0; kk < current_rows.size(); kk++)
         {
             const boost::dynamic_bitset<size_t>& row = current_rows.at(kk);
@@ -120,24 +120,78 @@ double open_ramps(const QubitOperator& oper,
             std::vector<Candidate> row_candidates;
             bitset_to_bitvec(row, row_set_bits);
 
+            // Row diagonal energy + occupied-orbital list, computed once per row.
+            // Each connected col's diagonal energy is then obtained incrementally across
+            // the 2-/4-bit flip in O(nflip * nelec) instead of the full O(nelec^2)
+            // single_bitstring_diagonal_fast sweep.
+            double e_row = 0;
+            std::vector<width_t> row_occ;
+            if(do_fast_diag)
+            {
+                single_bitstring_diagonal_fast(row, diag_oper.terms, row_ptrs, e_row);
+                row_occ = set_bit_indices(row);
+            }
+
             for(group = 0; group < num_groups; group++)
             {
                 group_inds = &group_offdiag_inds[group];
+
+                // Hamming-weight necessary condition (ported from the type-2
+                // element evaluators, e.g. csrlike_builder2.hpp): For a single
+                // excitation (2 inds) the two positions must differ; for a double
+                // excitation (4 inds) exactly two of the four must be occupied.
+                // Cheap reject before the ladder lookup, the col flip and
+                // the per-group diagonal energy evaluation below.
+                {
+                    const width_t _p = (*group_inds)[0];
+                    const width_t _q = (*group_inds)[1];
+                    if(group_inds->size() == 2)
+                    {
+                        if(row_set_bits[_p] == row_set_bits[_q])
+                        {
+                            continue;
+                        }
+                    }
+                    else if(group_inds->size() == 4)
+                    {
+                        const width_t _r = (*group_inds)[2];
+                        const width_t _s = (*group_inds)[3];
+                        if(_q < half_width && _r >= half_width)
+                        {
+                            // aabb: exactly one occupied in
+                            // the alpha pair and exactly one in the beta pair.
+                            if(row_set_bits[_p] + row_set_bits[_q] != 1 ||
+                               row_set_bits[_r] + row_set_bits[_s] != 1)
+                            {
+                                continue;
+                            }
+                        }
+                        // aaaa / bbbb: exactly two of four occupied
+                        else if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] +
+                                    row_set_bits[_s] !=
+                                2)
+                        {
+                            continue;
+                        }
+                    }
+                }
+
                 row_int = bitset_ladder_int(
                     row_set_bits.data(), group_inds->data(), group_rowint_length[group]);
                 group_int_start = group_ladder_ptrs[group * ladder_offset + row_int];
                 group_int_stop = group_ladder_ptrs[group * ladder_offset + row_int + 1];
-                do_col_search = 1;
+
+                if(group_int_start >= group_int_stop)
+                {
+                    continue;
+                }
+
+                col_vec = row;
+                flip_bits(col_vec, group_inds->data(), group_inds->size());
                 val = 0;
                 // begin loop over terms in this group
                 for(idx = group_int_start; idx < group_int_stop; idx++)
                 {
-                    if(do_col_search)
-                    {
-                        col_vec = row;
-                        flip_bits(col_vec, group_inds->data(), group_inds->size());
-                        do_col_search = 0;
-                    }
                     term = &oper.terms[idx];
                     if(passes_proj_validation(term, row))
                     {
@@ -152,11 +206,20 @@ double open_ramps(const QubitOperator& oper,
                     }
                 } // end loop over terms in this group
 
-                // Wwe need to compute the columns diagonal energy
+                // We need to compute the column's diagonal energy. In the delta-fast mode
+                // this is an incremental update from the row's diagonal energy across
+                // the group's bit-flip; otherwise fall back to the full evaluation.
                 col_energy = 0;
                 if(do_fast_diag)
                 {
-                    single_bitstring_diagonal_fast(col_vec, diag_oper.terms, row_ptrs, col_energy);
+                    col_energy = single_bitstring_diagonal_delta_fast(row,
+                                                                      col_vec,
+                                                                      row_occ,
+                                                                      diag_oper.terms,
+                                                                      row_ptrs,
+                                                                      group_inds->data(),
+                                                                      group_inds->size(),
+                                                                      e_row);
                 }
                 else
                 {

--- a/fulqrum/ramps/src/simple.hpp
+++ b/fulqrum/ramps/src/simple.hpp
@@ -45,6 +45,8 @@ double simple_restricted(const QubitOperator& oper,
     std::size_t recur, kk, current;
     // do stuff if the diagonal can be evaluated quickly
     bool do_fast_diag = fast_diag_compatible(diag_oper);
+    // alpha (spin-up) sector is the lower half of the bitset, beta the upper half
+    const width_t half_width = width / 2;
     std::vector<std::size_t> row_ptrs;
     if(do_fast_diag)
     {
@@ -101,19 +103,19 @@ double simple_restricted(const QubitOperator& oper,
         std::vector<std::vector<Candidate>> pending_candidates(current_rows.size());
 // Loop over all rows in the current set
 #pragma omp parallel for private(col_vec,                                                          \
-                                     group_inds,                                                   \
-                                     col_ptr,                                                      \
-                                     out_col_ptr,                                                  \
-                                     idx,                                                          \
-                                     group,                                                        \
-                                     group_int_start,                                              \
-                                     group_int_stop,                                               \
-                                     val,                                                          \
-                                     row_int,                                                      \
-                                     do_col_search,                                                \
-                                     col_energy,                                                   \
-                                     energy_amp,                                                   \
-                                     term) schedule(guided)
+                                 group_inds,                                                       \
+                                 col_ptr,                                                          \
+                                 out_col_ptr,                                                      \
+                                 idx,                                                              \
+                                 group,                                                            \
+                                 group_int_start,                                                  \
+                                 group_int_stop,                                                   \
+                                 val,                                                              \
+                                 row_int,                                                          \
+                                 do_col_search,                                                    \
+                                 col_energy,                                                       \
+                                 energy_amp,                                                       \
+                                 term) schedule(guided)
         for(kk = 0; kk < current_rows.size(); kk++)
         {
             const boost::dynamic_bitset<size_t>& row = input_bitsets[current_rows[kk]].first;
@@ -121,13 +123,70 @@ double simple_restricted(const QubitOperator& oper,
             std::vector<Candidate> row_candidates;
             bitset_to_bitvec(row, row_set_bits);
 
+            // Row diagonal energy + occupied-orbital list, computed once per row.
+            // Each in-subspace connected col's diagonal energy is then obtained
+            // incrementally across the 2-/4-bit flip in O(nflip * nelec) instead of
+            // the full O(nelec^2) single_bitstring_diagonal_fast sweep.
+            double e_row = 0;
+            std::vector<width_t> row_occ;
+            if(do_fast_diag)
+            {
+                single_bitstring_diagonal_fast(row, diag_oper.terms, row_ptrs, e_row);
+                row_occ = set_bit_indices(row);
+            }
+
             for(group = 0; group < num_groups; group++)
             {
                 group_inds = &group_offdiag_inds[group];
+
+                // Cheap reject (ported from csrlike_builder2.hpp): Single excitation
+                // (2 inds): the two positions must differ; double excitation (4 inds):
+                // exactly two of four must be occupied.
+                // Rejects before the ladder lookup, col flip and probe.
+                {
+                    const width_t _p = (*group_inds)[0];
+                    const width_t _q = (*group_inds)[1];
+                    if(group_inds->size() == 2)
+                    {
+                        if(row_set_bits[_p] == row_set_bits[_q])
+                        {
+                            continue;
+                        }
+                    }
+                    else if(group_inds->size() == 4)
+                    {
+                        const width_t _r = (*group_inds)[2];
+                        const width_t _s = (*group_inds)[3];
+                        if(_q < half_width && _r >= half_width)
+                        {
+                            // aabb: exactly one occupied in
+                            // the alpha pair and exactly one in the beta pair.
+                            if(row_set_bits[_p] + row_set_bits[_q] != 1 ||
+                               row_set_bits[_r] + row_set_bits[_s] != 1)
+                            {
+                                continue;
+                            }
+                        }
+                        // aaaa / bbbb: exactly two of four occupied
+                        else if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] +
+                                    row_set_bits[_s] !=
+                                2)
+                        {
+                            continue;
+                        }
+                    }
+                }
+
                 row_int = bitset_ladder_int(
                     row_set_bits.data(), group_inds->data(), group_rowint_length[group]);
                 group_int_start = group_ladder_ptrs[group * ladder_offset + row_int];
                 group_int_stop = group_ladder_ptrs[group * ladder_offset + row_int + 1];
+
+                if(group_int_start >= group_int_stop)
+                {
+                    continue;
+                }
+
                 do_col_search = 1;
                 val = 0;
                 // begin loop over terms in this group
@@ -160,11 +219,19 @@ double simple_restricted(const QubitOperator& oper,
 
                 if(!do_col_search)
                 {
-                    // If this column is in the subspace we need to compute the columns diagonal energy
+                    // This column is in the subspace: compute its diagonal energy.
+                    // In delta-fast mode do it incrementally from the row's diagonal
+                    // energy across the group's bit-flip; otherwise evaluate fully.
                     if(do_fast_diag)
                     {
-                        single_bitstring_diagonal_fast(
-                            input_bitsets[*col_ptr].first, diag_oper.terms, row_ptrs, col_energy);
+                        col_energy = single_bitstring_diagonal_delta_fast(row,
+                                                                          col_vec,
+                                                                          row_occ,
+                                                                          diag_oper.terms,
+                                                                          row_ptrs,
+                                                                          group_inds->data(),
+                                                                          group_inds->size(),
+                                                                          e_row);
                     }
                     else
                     {
@@ -176,7 +243,7 @@ double simple_restricted(const QubitOperator& oper,
                     // If the amplitude is larger than tol
                     if(std::abs(energy_amp) > tol)
                     {
-                        //if col not in out_subspace then add the column to the output subspace
+                        // if col not in out_subspace then add the column to the output subspace
                         // and add the col_ptr to the next rows array and add a new prefactor
                         // to the next_prefactors
                         out_col_ptr = out_subspace.get_ptr2(col_vec);


### PR DESCRIPTION
1. Accelerate both open and simple RAMPS.
    - Introduced a new variant of a faster diagonal energy evaluator `single_bitstring_diagonal_delta_fast()`. Read the function docstring for details.
    - Also, ported cheap Hamming weight-based rejection logic from {csr2, csrlike_builder2, matvec2}.hpp. 
3. Fix _matvec=None related error (see #67).
4. Bump version to `0.2.3` in both Python `__init__.py` and C++ `version.hpp`.