### PR TITLE
Cache friendly type 2 paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ FQ_BUILD_PARALLEL=8 pip install .
 FQ_BUILD_PARALLEL=8 python setup.py build_ext --inplace
 ```
 
+### Runtime performance tuning
+
+The type-2 build/matvec scripts (`csrlike_builder2`, `csr2`,
+`matvec2`) allows two optional **runtime** environment variables for tuning. Both have defaults and are read at run time (no rebuild needed), so they are safe to leave unset.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `FQ_BLK` | `128` | The number of rows in a block of rows. FQ_BLK number of rows reuses a chunk of group_ladder_ptrs. Larger blocks give more reuse but risk overflowing the per-core cache; smaller blocks reduce reuse. `128` is a good middle ground. Values `<= 0` are ignored. |
+| `FQ_LADDER_WIDTH` | `2` | Number of ladder bits used to bucket each group's terms, giving `2^FQ_LADDER_WIDTH` bins per group (so `2` → 4 bins, `4` → 16 bins). |
+
+Example: run a workload with a larger row block and finer ladder bucketing:
+
+```bash
+FQ_BLK=256 FQ_LADDER_WIDTH=4 python your_workload.py
+```
+
 ## Running benchmarks
 
 See the README.md in the `benchmarks` directory.

--- a/fulqrum/__init__.py
+++ b/fulqrum/__init__.py
@@ -12,7 +12,7 @@
 
 """Fulqrum"""
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 
 from .core import (

--- a/fulqrum/core/linear_operator.py
+++ b/fulqrum/core/linear_operator.py
@@ -12,6 +12,7 @@
 
 """Fulqrum linearoperator module"""
 
+import os
 import numpy as np
 from scipy.sparse.linalg import LinearOperator
 
@@ -50,7 +51,10 @@ class SubspaceHamiltonian(LinearOperator):
             self.group_ptrs = self.off_H.group_ptrs()
         if self.off_H.type == 2:
             if self.off_H.num_terms:
-                self.off_H.group_term_sort_by_ladder_int(4)
+                # Default changed from 4 to 2 as it is empirically faster.
+                # User can override using FQ_LADDER_WIDTH env flag.
+                self.off_H.group_term_sort_by_ladder_int(
+                    int(os.environ.get("FQ_LADDER_WIDTH", 2)))
                 self.group_ladder_ptrs = self.off_H.group_ladder_bin_starts()
 
         self.spmv = FulqrumSpMV(

--- a/fulqrum/core/linear_operator.py
+++ b/fulqrum/core/linear_operator.py
@@ -54,7 +54,8 @@ class SubspaceHamiltonian(LinearOperator):
                 # Default changed from 4 to 2 as it is empirically faster.
                 # User can override using FQ_LADDER_WIDTH env flag.
                 self.off_H.group_term_sort_by_ladder_int(
-                    int(os.environ.get("FQ_LADDER_WIDTH", 2)))
+                    int(os.environ.get("FQ_LADDER_WIDTH", 2))
+                )
                 self.group_ladder_ptrs = self.off_H.group_ladder_bin_starts()
 
         self.spmv = FulqrumSpMV(

--- a/fulqrum/core/src/constants.hpp
+++ b/fulqrum/core/src/constants.hpp
@@ -26,7 +26,7 @@ const std::size_t MAX_SIZE_T = (std::size_t)-1;
 const unsigned int MAX_UINT = (unsigned int)-1;
 const width_t MAX_WIDTH = (width_t)-1;
 const unsigned int BITS_PER_BLOCK = 8 * sizeof(std::size_t);
-const unsigned int DEFAULT_LADDER_WIDTH = 4;
+const unsigned int DEFAULT_LADDER_WIDTH = 2;
 const unsigned int BLOCK_EXPONENT = __builtin_ctz(BITS_PER_BLOCK);
 const unsigned int BLOCK_SHIFT = BITS_PER_BLOCK - 1;
 

--- a/fulqrum/core/src/csr2.hpp
+++ b/fulqrum/core/src/csr2.hpp
@@ -12,6 +12,7 @@
  * that they have been altered from the originals.
  */
 #pragma once
+#include <algorithm>
 #include <array>
 #include <complex>
 #include <cstdint>
@@ -65,6 +66,43 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
 
     const auto* bitsets = subspace.get_bitsets();
 
+    // See csrlike_builder2.hpp.
+    std::vector<width_t> _flat_inds;
+    std::vector<std::size_t> _inds_offsets;
+    flatten_offdiag_inds(group_offdiag_inds, _flat_inds, _inds_offsets);
+    const width_t* __restrict flat_inds = _flat_inds.data();
+    const std::size_t* __restrict inds_offsets = _inds_offsets.data();
+    auto gview = [&](std::size_t g) -> GroupIndsView {
+        const std::size_t off = inds_offsets[g];
+        return GroupIndsView{flat_inds + off, inds_offsets[g + 1] - off};
+    };
+
+    // See csrlike_builder2.hpp.
+    const std::size_t _ladder_len = static_cast<std::size_t>(num_groups) * ladder_offset + 1;
+    const bool _ladder_fits = terms.size() <= UINT32_MAX;
+    std::vector<std::uint32_t> _ladder32;
+    if(_ladder_fits)
+    {
+        _ladder32.resize(_ladder_len);
+        for(std::size_t i = 0; i < _ladder_len; ++i)
+            _ladder32[i] = static_cast<std::uint32_t>(group_ladder_ptrs[i]);
+    }
+    const std::uint32_t* __restrict ladder32 = _ladder32.data();
+    auto ladder = [&](std::size_t idx) -> std::size_t {
+        return _ladder_fits ? static_cast<std::size_t>(ladder32[idx]) : group_ladder_ptrs[idx];
+    };
+
+    // See csrlike_builder2.hpp.
+    std::size_t BLK = 128;
+    if(const char* _blk_env = std::getenv("FQ_BLK"))
+    {
+        long _v = std::atol(_blk_env);
+        if(_v > 0)
+            BLK = static_cast<std::size_t>(_v);
+    }
+    const std::size_t rsb_w = width; // one uint8 per qubit
+    const std::size_t num_blocks = (subspace_dim + BLK - 1) / BLK;
+
     // Categorize groups into buckets based on offdiag indices (mirror of
     // csrlike_builder2): aa / aaaa / bb / bbbb / aabb / other.  half_width
     // splits the bitset into the alpha (lower) and beta (upper) sectors.
@@ -78,7 +116,7 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
     const width_t half_width = width / 2;
     for(std::size_t g = 0; g < num_groups; g++)
     {
-        const auto& inds = group_offdiag_inds[g];
+        const GroupIndsView inds = gview(g);
         const std::size_t ind_size = inds.size();
 
         if(ind_size == 2)
@@ -173,14 +211,13 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
         }
     }
 
-    // ---- aabb fast-path prefilter setup -------------------------------------
+    // aabb fast-path prefilter setup
     // See csrlike_builder2.hpp for details.
     auto region_hash = [&](const boost::dynamic_bitset<std::size_t>& bs,
                            width_t lo,
                            width_t hi,
                            width_t fa,
                            width_t fb) -> std::uint64_t {
-
         const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
         const std::size_t hi_blk = static_cast<std::size_t>(hi - 1) >> BLOCK_EXPONENT;
         const std::size_t n_blk = hi_blk - lo_blk + 1;
@@ -231,7 +268,7 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
         std::unordered_map<std::uint32_t, std::uint32_t> b_pair_id;
         for(const auto& g : aabb_fast_groups)
         {
-            const auto& inds = group_offdiag_inds[g];
+            const GroupIndsView inds = gview(g);
             const width_t ap0 = inds[0], ap1 = inds[1], bp0 = inds[2], bp1 = inds[3];
             const std::uint32_t ak = (std::uint32_t(ap0) << 16) | ap1;
             const std::uint32_t bk = (std::uint32_t(bp0) << 16) | bp1;
@@ -290,234 +327,236 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
         }
     }
 
-#pragma omp parallel for schedule(dynamic) if(subspace_dim > 4096)
-    for(kk = 0; kk < subspace_dim; kk++)
-    { // begin loop over all rows
-        const boost::dynamic_bitset<size_t>& row = bitsets[kk].first;
-
-        // define variables locally for omp for loop
-        std::size_t idx;
-        std::size_t group_int_start, group_int_stop;
-        const OperatorTerm_t* term;
-        boost::dynamic_bitset<std::size_t> col_vec;
-        const std::vector<width_t>* group_inds;
-        std::size_t* col_ptr;
-        std::size_t col_idx;
-        U val;
-        unsigned int row_int;
-
-        T& row_nnz = row_nnz_s[kk];
-        T& elem_start = indptr[kk];
-
-        std::vector<uint8_t> row_set_bits(row.size(), 0);
-        bitset_to_bitvec(row, row_set_bits);
-
-        // Per-row aabb prefilter (distinct alpha/beta pair validity).
+    // See csrlike_builder2.hpp for details.
+    const std::size_t rsb_w2 = rsb_w;
+#pragma omp parallel if(subspace_dim > 4096)
+    {
+        // Per-thread scratch, reused across blocks (no per-block realloc).
+        std::vector<uint8_t> rsb_buf;
         std::vector<char> alpha_ok(num_a_pairs);
         std::vector<char> beta_ok(num_b_pairs);
+        boost::dynamic_bitset<std::size_t> col_vec;
 
-        auto range_parity = [&](width_t lo, width_t hi) -> std::size_t {
-            if(lo >= hi)
-            {
-                return 0;
-            }
-            const width_t last = hi - 1; // inclusive last bit
-            const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
-            const std::size_t hi_blk = static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
-            const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
-            const std::size_t hi_mask = ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
-
-            std::size_t acc;
-            if(lo_blk == hi_blk)
-            {
-                acc = row.m_bits[lo_blk] & lo_mask & hi_mask;
-            }
-            else
-            {
-                acc = row.m_bits[lo_blk] & lo_mask;
-                for(std::size_t b = lo_blk + 1; b < hi_blk; b++)
-                {
-                    acc ^= row.m_bits[b];
-                }
-                acc ^= row.m_bits[hi_blk] & hi_mask;
-            }
-            return static_cast<std::size_t>(
-                __builtin_parityll(static_cast<unsigned long long>(acc)));
-        };
-
-        // Emit a single (kk, col_idx, v) entry for this row.  No transpose
-        // write, so no mutex is needed: each row is owned by one thread.
-        auto emit = [&](std::size_t cidx, const U& v) {
-            if(compute_values)
-            {
-                indices[elem_start + row_nnz] = cidx;
-                data[elem_start + row_nnz] = v;
-            }
-            row_nnz += 1;
-        };
-
-        // Standard per-group path: validity check -> ladder lookup -> col flip
-        // -> subspace lookup -> term loop -> emit.  Shared by aa, aaaa, bb,
-        // bbbb, aabb_slow and other_groups.
-        auto process_standard_group = [&](std::size_t g) {
-            group_inds = &group_offdiag_inds[g];
-
-            // Hamming weight check.
-            // Flip pos must have equal number of 1s and 0s.
-            const width_t _p = (*group_inds)[0];
-            const width_t _q = (*group_inds)[1];
-
-            if(group_inds->size() == 2)
-            {
-                if(row_set_bits[_p] == row_set_bits[_q])
-                {
-                    return;
-                }
-            }
-            else if(group_inds->size() == 4)
-            {
-                const width_t _r = (*group_inds)[2];
-                const width_t _s = (*group_inds)[3];
-                if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] + row_set_bits[_s] != 2)
-                {
-                    return;
-                }
-            }
-
-            row_int =
-                bitset_ladder_int(row_set_bits.data(), group_inds->data(), group_rowint_length[g]);
-            group_int_start = group_ladder_ptrs[g * ladder_offset + row_int];
-            group_int_stop = group_ladder_ptrs[g * ladder_offset + row_int + 1];
-
-            if(group_int_start >= group_int_stop)
-            {
-                return;
-            }
-
-            col_vec = row;
-            flip_bits(col_vec, group_inds->data(), group_inds->size());
-
-            col_ptr = subspace.get_ptr(col_vec);
-            if(col_ptr == nullptr)
-            {
-                return;
-            }
-            col_idx = *col_ptr;
-
-            val = 0;
-            for(idx = group_int_start; idx < group_int_stop; idx++)
-            {
-                term = &terms[idx];
-                if(passes_proj_validation(term, row))
-                {
-                    accum_element(row,
-                                  col_vec,
-                                  term->indices,
-                                  term->values,
-                                  term->coeff,
-                                  term->real_phase,
-                                  term->indices.size(),
-                                  val);
-                }
-            }
-
-            if(std::abs(val) > ATOL)
-            {
-                emit(col_idx, val);
-            }
-        };
-
-        for(const auto& g : aa_groups)
-            process_standard_group(g);
-        for(const auto& g : aaaa_groups)
-            process_standard_group(g);
-        for(const auto& g : bb_groups)
-            process_standard_group(g);
-
-        for(std::size_t i = 0; i < num_a_pairs; ++i)
+#pragma omp for schedule(dynamic)
+        for(std::size_t blk = 0; blk < num_blocks; ++blk)
         {
-            const width_t p0 = a_pairs[i][0];
-            const width_t p1 = a_pairs[i][1];
-            if(row_set_bits[p0] == row_set_bits[p1])
-            {
-                alpha_ok[i] = 0;
-                continue;
-            }
-            alpha_ok[i] = alpha_half_hashes.contains(region_hash(row, 0, half_width, p0, p1));
-        }
-        for(std::size_t j = 0; j < num_b_pairs; ++j)
-        {
-            const width_t p0 = b_pairs[j][0];
-            const width_t p1 = b_pairs[j][1];
-            if(row_set_bits[p0] == row_set_bits[p1])
-            {
-                beta_ok[j] = 0;
-                continue;
-            }
-            beta_ok[j] = beta_half_hashes.contains(region_hash(row, half_width, width, p0, p1));
-        }
+            const std::size_t r0 = blk * BLK;
+            const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
+            const std::size_t bn = r1 - r0;
 
-        for(std::size_t i = 0; i < num_a_pairs; ++i)
-        {
-            if(!alpha_ok[i])
+            // row_set_bits for every row in the block, contiguous.
+            rsb_buf.assign(bn * rsb_w2, 0);
+            for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
             {
-                continue;
-            }
-            const width_t ap0 = a_pairs[i][0];
-            const width_t ap1 = a_pairs[i][1];
-            for(const auto& e : aabb_by_alpha[i])
-            {
-                if(!beta_ok[e.b_id])
+                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
+                uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w2;
+                for(std::size_t b = 0; b < row.num_blocks(); ++b)
                 {
-                    continue;
+                    std::size_t bits = row.m_bits[b];
+                    while(bits != 0)
+                    {
+                        int r = __builtin_ctzll(bits);
+                        dst[b * BITS_PER_BLOCK + r] = 1;
+                        bits &= bits - 1;
+                    }
                 }
-                group_inds = &group_offdiag_inds[e.g];
-                const width_t bp0 = (*group_inds)[2];
-                const width_t bp1 = (*group_inds)[3];
+            }
 
-                row_int = bitset_ladder_int(
-                    row_set_bits.data(), group_inds->data(), group_rowint_length[e.g]);
-                group_int_start = group_ladder_ptrs[e.g * ladder_offset + row_int];
-                group_int_stop = group_ladder_ptrs[e.g * ladder_offset + row_int + 1];
+            // Emit a single (row r0+row_in_block, col_idx, v) entry.
+            // row_nnz_s[r0+row_in_block] and indptr[r0+row_in_block] give the CSR write position.
+            auto emit = [&](std::size_t row_in_block, std::size_t cidx, const U& v) {
+                T& row_nnz = row_nnz_s[r0 + row_in_block];
+                if(compute_values)
+                {
+                    const T elem_start = indptr[r0 + row_in_block];
+                    indices[elem_start + row_nnz] = cidx;
+                    data[elem_start + row_nnz] = v;
+                }
+                row_nnz += 1;
+            };
+
+            // Standard per-group path for one (group g, row_in_block) pair.
+            auto process_standard_group = [&](std::size_t g, std::size_t row_in_block) {
+                const GroupIndsView group_inds = gview(g);
+                const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w2;
+
+                // Hamming weight check.
+                const width_t _p = group_inds[0];
+                const width_t _q = group_inds[1];
+                if(group_inds.size() == 2)
+                {
+                    if(row_set_bits[_p] == row_set_bits[_q])
+                        return;
+                }
+                else if(group_inds.size() == 4)
+                {
+                    const width_t _r = group_inds[2];
+                    const width_t _s = group_inds[3];
+                    if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] + row_set_bits[_s] !=
+                       2)
+                        return;
+                }
+
+                const unsigned int row_int =
+                    bitset_ladder_int(row_set_bits, group_inds.data(), group_rowint_length[g]);
+                const std::size_t group_int_start = ladder(g * ladder_offset + row_int);
+                const std::size_t group_int_stop = ladder(g * ladder_offset + row_int + 1);
                 if(group_int_start >= group_int_stop)
-                {
-                    continue;
-                }
+                    return;
 
+                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
                 col_vec = row;
-                flip_bits(col_vec, group_inds->data(), group_inds->size());
-                col_ptr = subspace.get_ptr(col_vec);
+                flip_bits(col_vec, group_inds.data(), group_inds.size());
+
+                std::size_t* col_ptr = subspace.get_ptr(col_vec);
                 if(col_ptr == nullptr)
+                    return;
+                const std::size_t col_idx = *col_ptr;
+
+                U val = 0;
+                for(std::size_t idx = group_int_start; idx < group_int_stop; idx++)
                 {
-                    continue;
+                    const OperatorTerm_t* term = &terms[idx];
+                    if(passes_proj_validation(term, row))
+                    {
+                        accum_element(row,
+                                      col_vec,
+                                      term->indices,
+                                      term->values,
+                                      term->coeff,
+                                      term->real_phase,
+                                      term->indices.size(),
+                                      val);
+                    }
                 }
-                col_idx = *col_ptr;
-
-                const std::size_t aabb_parity =
-                    range_parity(ap0 + 1, ap1) ^ range_parity(bp0 + 1, bp1);
-                double sign = aabb_parity ? -1.0 : 1.0;
-
-                val = aabb_direct[e.g] * static_cast<U>(sign);
 
                 if(std::abs(val) > ATOL)
+                    emit(row_in_block, col_idx, val);
+            };
+
+            for(const auto& g : aa_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+            for(const auto& g : aaaa_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+            for(const auto& g : bb_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+
+            // aabb fast path, ROW-major within the block to preserve the per-row
+            // alpha/beta prefilter skip.
+            if(!aabb_fast_groups.empty())
+            {
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
                 {
-                    emit(col_idx, val);
+                    const boost::dynamic_bitset<std::size_t>& row =
+                        bitsets[r0 + row_in_block].first;
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w2;
+
+                    auto range_parity = [&](width_t lo, width_t hi) -> std::size_t {
+                        if(lo >= hi)
+                            return 0;
+                        const width_t last = hi - 1; // inclusive last bit
+                        const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
+                        const std::size_t hi_blk = static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
+                        const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
+                        const std::size_t hi_mask =
+                            ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
+                        std::size_t acc;
+                        if(lo_blk == hi_blk)
+                        {
+                            acc = row.m_bits[lo_blk] & lo_mask & hi_mask;
+                        }
+                        else
+                        {
+                            acc = row.m_bits[lo_blk] & lo_mask;
+                            for(std::size_t b = lo_blk + 1; b < hi_blk; b++)
+                                acc ^= row.m_bits[b];
+                            acc ^= row.m_bits[hi_blk] & hi_mask;
+                        }
+                        return static_cast<std::size_t>(
+                            __builtin_parityll(static_cast<unsigned long long>(acc)));
+                    };
+
+                    for(std::size_t i = 0; i < num_a_pairs; ++i)
+                    {
+                        const width_t p0 = a_pairs[i][0];
+                        const width_t p1 = a_pairs[i][1];
+                        if(row_set_bits[p0] == row_set_bits[p1])
+                        {
+                            alpha_ok[i] = 0;
+                            continue;
+                        }
+                        alpha_ok[i] =
+                            alpha_half_hashes.contains(region_hash(row, 0, half_width, p0, p1));
+                    }
+                    for(std::size_t j = 0; j < num_b_pairs; ++j)
+                    {
+                        const width_t p0 = b_pairs[j][0];
+                        const width_t p1 = b_pairs[j][1];
+                        if(row_set_bits[p0] == row_set_bits[p1])
+                        {
+                            beta_ok[j] = 0;
+                            continue;
+                        }
+                        beta_ok[j] =
+                            beta_half_hashes.contains(region_hash(row, half_width, width, p0, p1));
+                    }
+
+                    for(std::size_t i = 0; i < num_a_pairs; ++i)
+                    {
+                        if(!alpha_ok[i])
+                            continue;
+                        const width_t ap0 = a_pairs[i][0];
+                        const width_t ap1 = a_pairs[i][1];
+                        for(const auto& e : aabb_by_alpha[i])
+                        {
+                            if(!beta_ok[e.b_id])
+                                continue;
+                            const GroupIndsView group_inds = gview(e.g);
+                            const width_t bp0 = group_inds[2];
+                            const width_t bp1 = group_inds[3];
+
+                            const unsigned int row_int = bitset_ladder_int(
+                                row_set_bits, group_inds.data(), group_rowint_length[e.g]);
+                            const std::size_t group_int_start =
+                                ladder(e.g * ladder_offset + row_int);
+                            const std::size_t group_int_stop =
+                                ladder(e.g * ladder_offset + row_int + 1);
+                            if(group_int_start >= group_int_stop)
+                                continue;
+
+                            col_vec = row;
+                            flip_bits(col_vec, group_inds.data(), group_inds.size());
+                            std::size_t* col_ptr = subspace.get_ptr(col_vec);
+                            if(col_ptr == nullptr)
+                                continue;
+                            const std::size_t col_idx = *col_ptr;
+
+                            const std::size_t aabb_parity =
+                                range_parity(ap0 + 1, ap1) ^ range_parity(bp0 + 1, bp1);
+                            double sign = aabb_parity ? -1.0 : 1.0;
+                            U val = aabb_direct[e.g] * static_cast<U>(sign);
+
+                            if(std::abs(val) > ATOL)
+                                emit(row_in_block, col_idx, val);
+                        }
+                    }
                 }
             }
-        }
 
-        // aabb slow path: terms within a group have differing coeff or
-        // real_phase, so the direct asign*bsign formula doesn't apply.
-        for(const auto& g : aabb_slow_groups)
-            process_standard_group(g);
-
-        for(const auto& g : bbbb_groups)
-            process_standard_group(g);
-
-        // other_groups is supposed to be empty. Kept here for safety.
-        for(const auto& g : other_groups)
-            process_standard_group(g);
-    } // end loop over all rows
+            for(const auto& g : aabb_slow_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+            for(const auto& g : bbbb_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+            for(const auto& g : other_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+        } // end loop over blocks
+    } // end parallel region
 
     if(!compute_values) // Done with all rows so accumulate for correct indptr structure
     {

--- a/fulqrum/core/src/csrlike_builder2.hpp
+++ b/fulqrum/core/src/csrlike_builder2.hpp
@@ -12,6 +12,7 @@
  * that they have been altered from the originals.
  */
 #pragma once
+#include <algorithm>
 #include <array>
 #include <complex>
 #include <cstdint>
@@ -51,6 +52,54 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
     std::size_t kk;
     const auto* bitsets = subspace.get_bitsets();
 
+    // Flatten group_offdiag_inds (vector<vector> -> contiguous CSR) once.
+    // Inner vec in a 2D vector can be scattered across the heap. Contiguos CSR
+    // has more favorable memory access pattern. Shows decent speed-up in tests.
+    // The one-time flatten is negligible. Output is unchanged.
+    std::vector<width_t> _flat_inds;
+    std::vector<std::size_t> _inds_offsets;
+    flatten_offdiag_inds(group_offdiag_inds, _flat_inds, _inds_offsets);
+    const width_t* __restrict flat_inds = _flat_inds.data();
+    const std::size_t* __restrict inds_offsets = _inds_offsets.data();
+    auto gview = [&](std::size_t g) -> GroupIndsView {
+        const std::size_t off = inds_offsets[g];
+        return GroupIndsView{flat_inds + off, inds_offsets[g + 1] - off};
+    };
+
+    // Make ladder table leaner: size_t -> uint32 once.
+    // A lean table is more cache-friendly.
+    // Any reasonable operator will have <= UINT32_MAX terms.
+    // For the (very unlikely) > 2^32-term operator we skip the lean table
+    // and read the original size_t table via ladder(), so we never silently
+    // truncate an offset.
+    const std::size_t _ladder_len = num_groups * ladder_offset + 1;
+    const bool _ladder_fits = terms.size() <= UINT32_MAX;
+    std::vector<std::uint32_t> _ladder32;
+    if(_ladder_fits)
+    {
+        _ladder32.resize(_ladder_len);
+        for(std::size_t i = 0; i < _ladder_len; ++i)
+            _ladder32[i] = static_cast<std::uint32_t>(group_ladder_ptrs[i]);
+    }
+    const std::uint32_t* __restrict ladder32 = _ladder32.data();
+
+    auto ladder = [&](std::size_t idx) -> std::size_t {
+        return _ladder_fits ? static_cast<std::size_t>(ladder32[idx]) : group_ladder_ptrs[idx];
+    };
+
+    // BLK defines number of rows that we process per group in one iter.
+    // Group middle x block of rows inner iteration order cut down cache misses
+    // significantly. BLK=128 is a good middle-ground.
+    // A too large of BLK may overflow cache.
+    // User can override it through env var FQ_BLK.
+    std::size_t BLK = 128;
+    if(const char* _blk_env = std::getenv("FQ_BLK"))
+    {
+        long _blk = std::atol(_blk_env);
+        if(_blk > 0)
+            BLK = static_cast<std::size_t>(_blk);
+    }
+
     cols.resize(subspace_dim);
     data.resize(subspace_dim);
 
@@ -65,7 +114,7 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
     const width_t half_width = width / 2;
     for(std::size_t g = 0; g < num_groups; g++)
     {
-        const auto& inds = group_offdiag_inds[g];
+        const GroupIndsView inds = gview(g);
         const std::size_t ind_size = inds.size();
 
         if(ind_size == 2)
@@ -166,7 +215,7 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
         }
     }
 
-    // ---- aabb fast-path prefilter setup -------------------------------------
+    // aabb fast-path prefilter setup
     // The aabb hot loop is O(subspace_dim * num_aabb_groups) with mostly misses
     // (most columns are not in the subspace).
     //
@@ -183,7 +232,6 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
                            width_t hi,
                            width_t fa,
                            width_t fb) -> std::uint64_t {
-
         const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
         const std::size_t hi_blk = static_cast<std::size_t>(hi - 1) >> BLOCK_EXPONENT;
         const std::size_t n_blk = hi_blk - lo_blk + 1;
@@ -234,7 +282,7 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
         std::unordered_map<std::uint32_t, std::uint32_t> b_pair_id;
         for(const auto& g : aabb_fast_groups)
         {
-            const auto& inds = group_offdiag_inds[g];
+            const GroupIndsView inds = gview(g);
             const width_t ap0 = inds[0], ap1 = inds[1], bp0 = inds[2], bp1 = inds[3];
             const std::uint32_t ak = (std::uint32_t(ap0) << 16) | ap1;
             const std::uint32_t bk = (std::uint32_t(bp0) << 16) | bp1;
@@ -286,232 +334,241 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
         }
     }
 
-#pragma omp parallel for schedule(dynamic) if(subspace_dim > 4096)
-    for(kk = 0; kk < subspace_dim; kk++)
-    { // begin loop over all rows
-        const boost::dynamic_bitset<size_t>& row = bitsets[kk].first;
+    const std::size_t rsb_w = width; // one uint8 per qubit
+    const std::size_t num_blocks = (subspace_dim + BLK - 1) / BLK;
 
-        // define variables locally for omp for loop
-        std::size_t idx;
-        std::size_t group_int_start, group_int_stop;
-        const OperatorTerm_t* term;
-        boost::dynamic_bitset<std::size_t> col_vec;
-        const std::vector<width_t>* group_inds;
-        std::size_t* col_ptr;
-        std::size_t col_idx;
-        T val;
-        unsigned int row_int;
-
-        std::vector<uint8_t> row_set_bits(row.size(), 0);
-        bitset_to_bitvec(row, row_set_bits);
-
-        // Per-row aabb prefilter (distinct alpha/beta pair validity).
+    // New loop order: block-of-rows outer, group middle, row inner
+    // for block_of_rows in rows:
+    //   for g in groups:
+    //     for row in block_of_rows:
+    //       ...
+    // In group_ladder_ptrs[g * ladder_offset + row_int] lookup, row_int varies only over [0, ladder_offset - 1]
+    // (= [0,3] if ladder_width=2, [0,15] if ladder_width=4). For a fixed g, the first
+    // row in the block of rows fetches a cache-line of group_ladder_ptrs[] that can be resued by remaining rows
+    // while being cache resident.
+#pragma omp parallel if(subspace_dim > 4096)
+    {
+        // Per-thread scratch, reused across blocks (no per-block realloc).
+        std::vector<uint8_t> rsb_buf;
         std::vector<char> alpha_ok(num_a_pairs);
         std::vector<char> beta_ok(num_b_pairs);
+        boost::dynamic_bitset<std::size_t> col_vec;
 
-        auto range_parity = [&](width_t lo, width_t hi) -> std::size_t {
-            if(lo >= hi)
-            {
-                return 0;
-            }
-            const width_t last = hi - 1; // inclusive last bit
-            const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
-            const std::size_t hi_blk = static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
-            const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
-            const std::size_t hi_mask = ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
-
-            std::size_t acc;
-            if(lo_blk == hi_blk)
-            {
-                acc = row.m_bits[lo_blk] & lo_mask & hi_mask;
-            }
-            else
-            {
-                acc = row.m_bits[lo_blk] & lo_mask;
-                for(std::size_t b = lo_blk + 1; b < hi_blk; b++)
-                {
-                    acc ^= row.m_bits[b];
-                }
-                acc ^= row.m_bits[hi_blk] & hi_mask;
-            }
-            return static_cast<std::size_t>(
-                __builtin_parityll(static_cast<unsigned long long>(acc)));
-        };
-
-        // Standard per-group path: ladder lookup -> col flip -> subspace lookup
-        // -> term loop -> emit.  Shared by aa, aaaa, bb, bbbb, aabb_slow (and
-        // the other_groups).
-        auto process_standard_group = [&](std::size_t g) {
-            group_inds = &group_offdiag_inds[g];
-
-            // Hamming weight check.
-            // Flip pos must have equal number of 1s and 0s.
-            const width_t _p = (*group_inds)[0];
-            const width_t _q = (*group_inds)[1];
-
-            if(group_inds->size() == 2)
-            {
-                if(row_set_bits[_p] == row_set_bits[_q])
-                {
-                    return;
-                }
-            }
-            else if(group_inds->size() == 4)
-            {
-                const width_t _r = (*group_inds)[2];
-                const width_t _s = (*group_inds)[3];
-                if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] + row_set_bits[_s] != 2)
-                {
-                    return;
-                }
-            }
-
-            row_int =
-                bitset_ladder_int(row_set_bits.data(), group_inds->data(), group_rowint_length[g]);
-            group_int_start = group_ladder_ptrs[g * ladder_offset + row_int];
-            group_int_stop = group_ladder_ptrs[g * ladder_offset + row_int + 1];
-
-            if(group_int_start >= group_int_stop)
-            {
-                return;
-            }
-
-            col_vec = row;
-            flip_bits(col_vec, group_inds->data(), group_inds->size());
-
-            col_ptr = subspace.get_ptr(col_vec);
-            if(col_ptr == nullptr)
-            {
-                return;
-            }
-            col_idx = *col_ptr;
-
-            val = 0;
-            for(idx = group_int_start; idx < group_int_stop; idx++)
-            {
-                term = &terms[idx];
-                if(passes_proj_validation(term, row))
-                {
-                    accum_element(row,
-                                  col_vec,
-                                  term->indices,
-                                  term->values,
-                                  term->coeff,
-                                  term->real_phase,
-                                  term->indices.size(),
-                                  val);
-                }
-            }
-
-            if(std::abs(val) > ATOL)
-            {
-                cols[kk].push_back(col_idx);
-                data[kk].push_back(val);
-            }
-        };
-
-        for(const auto& g : aa_groups)
-            process_standard_group(g);
-        for(const auto& g : aaaa_groups)
-            process_standard_group(g);
-        for(const auto& g : bb_groups)
-            process_standard_group(g);
-
-        // Process aabb fast groups (size==4, 2 alpha + 2 beta indices, every
-        // term in the group shares a single coeff and real_phase).  Matrix
-        // element = coeff * asign * bsign; skip the term loop.
-        //
-        // Necessary-condition prefilter: evaluate "alpha-half flip matches
-        // some subspace alpha-half" once per distinct alpha pair (same for beta)
-        // then visit groups grouped by alpha pair.
-        // A failing alpha pair skips all its groups with no bitset
-        // copy and no subspace probe. The exact subspace.get_ptr below still
-        // confirms membership.
-        for(std::size_t i = 0; i < num_a_pairs; ++i)
+#pragma omp for schedule(dynamic)
+        for(std::size_t blk = 0; blk < num_blocks; ++blk)
         {
-            const width_t p0 = a_pairs[i][0];
-            const width_t p1 = a_pairs[i][1];
-            if(row_set_bits[p0] == row_set_bits[p1])
-            {
-                alpha_ok[i] = 0;
-                continue;
-            }
-            alpha_ok[i] = alpha_half_hashes.contains(region_hash(row, 0, half_width, p0, p1));
-        }
-        for(std::size_t j = 0; j < num_b_pairs; ++j)
-        {
-            const width_t p0 = b_pairs[j][0];
-            const width_t p1 = b_pairs[j][1];
-            if(row_set_bits[p0] == row_set_bits[p1])
-            {
-                beta_ok[j] = 0;
-                continue;
-            }
-            beta_ok[j] = beta_half_hashes.contains(region_hash(row, half_width, width, p0, p1));
-        }
+            const std::size_t r0 = blk * BLK;
+            const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
+            const std::size_t bn = r1 - r0;
 
-        for(std::size_t i = 0; i < num_a_pairs; ++i)
-        {
-            if(!alpha_ok[i])
+            // row_set_bits for every row in the block, 1D contiguous vec.
+            rsb_buf.assign(bn * rsb_w, 0);
+            for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
             {
-                continue;
-            }
-            const width_t ap0 = a_pairs[i][0];
-            const width_t ap1 = a_pairs[i][1];
-            for(const auto& e : aabb_by_alpha[i])
-            {
-                if(!beta_ok[e.b_id])
+                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
+                uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
+                for(std::size_t b = 0; b < row.num_blocks(); ++b)
                 {
-                    continue;
+                    std::size_t bits = row.m_bits[b];
+                    while(bits != 0)
+                    {
+                        int r = __builtin_ctzll(bits);
+                        dst[b * BITS_PER_BLOCK + r] = 1;
+                        bits &= bits - 1;
+                    }
                 }
-                group_inds = &group_offdiag_inds[e.g];
-                const width_t bp0 = (*group_inds)[2];
-                const width_t bp1 = (*group_inds)[3];
+            }
 
-                // only runs for prefiltered candidates.
-                row_int = bitset_ladder_int(
-                    row_set_bits.data(), group_inds->data(), group_rowint_length[e.g]);
-                group_int_start = group_ladder_ptrs[e.g * ladder_offset + row_int];
-                group_int_stop = group_ladder_ptrs[e.g * ladder_offset + row_int + 1];
+            // Standard per-group path for one (group g, row_in_block) pair.
+            auto process_standard_group = [&](std::size_t g, std::size_t row_in_block) {
+                const GroupIndsView group_inds = gview(g);
+                const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+
+                // Hamming weight check.
+                const width_t _p = group_inds[0];
+                const width_t _q = group_inds[1];
+                if(group_inds.size() == 2)
+                {
+                    if(row_set_bits[_p] == row_set_bits[_q])
+                        return;
+                }
+                else if(group_inds.size() == 4)
+                {
+                    const width_t _r = group_inds[2];
+                    const width_t _s = group_inds[3];
+                    if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] + row_set_bits[_s] !=
+                       2)
+                        return;
+                }
+
+                const unsigned int row_int =
+                    bitset_ladder_int(row_set_bits, group_inds.data(), group_rowint_length[g]);
+                const std::size_t group_int_start = ladder(g * ladder_offset + row_int);
+                const std::size_t group_int_stop = ladder(g * ladder_offset + row_int + 1);
                 if(group_int_start >= group_int_stop)
-                {
-                    continue;
-                }
+                    return;
 
+                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
                 col_vec = row;
-                flip_bits(col_vec, group_inds->data(), group_inds->size());
-                col_ptr = subspace.get_ptr(col_vec);
+                flip_bits(col_vec, group_inds.data(), group_inds.size());
+
+                std::size_t* col_ptr = subspace.get_ptr(col_vec);
                 if(col_ptr == nullptr)
+                    return;
+                const std::size_t col_idx = *col_ptr;
+
+                T val = 0;
+                for(std::size_t idx = group_int_start; idx < group_int_stop; idx++)
                 {
-                    continue;
+                    const OperatorTerm_t* term = &terms[idx];
+                    if(passes_proj_validation(term, row))
+                    {
+                        accum_element(row,
+                                      col_vec,
+                                      term->indices,
+                                      term->values,
+                                      term->coeff,
+                                      term->real_phase,
+                                      term->indices.size(),
+                                      val);
+                    }
                 }
-                col_idx = *col_ptr;
-
-                const std::size_t aabb_parity =
-                    range_parity(ap0 + 1, ap1) ^ range_parity(bp0 + 1, bp1);
-                double sign = aabb_parity ? -1.0 : 1.0;
-
-                val = aabb_direct[e.g] * static_cast<T>(sign);
 
                 if(std::abs(val) > ATOL)
                 {
-                    cols[kk].push_back(col_idx);
-                    data[kk].push_back(val);
+                    cols[r0 + row_in_block].push_back(col_idx);
+                    data[r0 + row_in_block].push_back(val);
+                }
+            };
+
+            // aa / aaaa / bb (group-outer, row-inner).
+            for(const auto& g : aa_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+            for(const auto& g : aaaa_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+            for(const auto& g : bb_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+
+            // aabb fast path, ROW-major within the block to preserve the
+            // per-row alpha/beta prefilter skip (a failing alpha pair drops all
+            // its groups at once).
+            if(!aabb_fast_groups.empty())
+            {
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                {
+                    const boost::dynamic_bitset<std::size_t>& row =
+                        bitsets[r0 + row_in_block].first;
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+
+                    auto range_parity = [&](width_t lo, width_t hi) -> std::size_t {
+                        if(lo >= hi)
+                            return 0;
+                        const width_t last = hi - 1; // inclusive last bit
+                        const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
+                        const std::size_t hi_blk = static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
+                        const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
+                        const std::size_t hi_mask =
+                            ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
+                        std::size_t acc;
+                        if(lo_blk == hi_blk)
+                        {
+                            acc = row.m_bits[lo_blk] & lo_mask & hi_mask;
+                        }
+                        else
+                        {
+                            acc = row.m_bits[lo_blk] & lo_mask;
+                            for(std::size_t b = lo_blk + 1; b < hi_blk; b++)
+                                acc ^= row.m_bits[b];
+                            acc ^= row.m_bits[hi_blk] & hi_mask;
+                        }
+                        return static_cast<std::size_t>(
+                            __builtin_parityll(static_cast<unsigned long long>(acc)));
+                    };
+
+                    for(std::size_t i = 0; i < num_a_pairs; ++i)
+                    {
+                        const width_t p0 = a_pairs[i][0];
+                        const width_t p1 = a_pairs[i][1];
+                        if(row_set_bits[p0] == row_set_bits[p1])
+                        {
+                            alpha_ok[i] = 0;
+                            continue;
+                        }
+                        alpha_ok[i] =
+                            alpha_half_hashes.contains(region_hash(row, 0, half_width, p0, p1));
+                    }
+                    for(std::size_t j = 0; j < num_b_pairs; ++j)
+                    {
+                        const width_t p0 = b_pairs[j][0];
+                        const width_t p1 = b_pairs[j][1];
+                        if(row_set_bits[p0] == row_set_bits[p1])
+                        {
+                            beta_ok[j] = 0;
+                            continue;
+                        }
+                        beta_ok[j] =
+                            beta_half_hashes.contains(region_hash(row, half_width, width, p0, p1));
+                    }
+
+                    for(std::size_t i = 0; i < num_a_pairs; ++i)
+                    {
+                        if(!alpha_ok[i])
+                            continue;
+                        const width_t ap0 = a_pairs[i][0];
+                        const width_t ap1 = a_pairs[i][1];
+                        for(const auto& e : aabb_by_alpha[i])
+                        {
+                            if(!beta_ok[e.b_id])
+                                continue;
+                            const GroupIndsView group_inds = gview(e.g);
+                            const width_t bp0 = group_inds[2];
+                            const width_t bp1 = group_inds[3];
+
+                            const unsigned int row_int = bitset_ladder_int(
+                                row_set_bits, group_inds.data(), group_rowint_length[e.g]);
+                            const std::size_t group_int_start =
+                                ladder(e.g * ladder_offset + row_int);
+                            const std::size_t group_int_stop =
+                                ladder(e.g * ladder_offset + row_int + 1);
+                            if(group_int_start >= group_int_stop)
+                                continue;
+
+                            col_vec = row;
+                            flip_bits(col_vec, group_inds.data(), group_inds.size());
+                            std::size_t* col_ptr = subspace.get_ptr(col_vec);
+                            if(col_ptr == nullptr)
+                                continue;
+                            const std::size_t col_idx = *col_ptr;
+
+                            const std::size_t aabb_parity =
+                                range_parity(ap0 + 1, ap1) ^ range_parity(bp0 + 1, bp1);
+                            double sign = aabb_parity ? -1.0 : 1.0;
+                            T val = aabb_direct[e.g] * static_cast<T>(sign);
+
+                            if(std::abs(val) > ATOL)
+                            {
+                                cols[r0 + row_in_block].push_back(col_idx);
+                                data[r0 + row_in_block].push_back(val);
+                            }
+                        }
+                    }
                 }
             }
+
+            // aabb_slow / bbbb / other (group-outer, row-inner).
+            for(const auto& g : aabb_slow_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+            for(const auto& g : bbbb_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
+            for(const auto& g : other_groups)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                    process_standard_group(g, row_in_block);
         }
-
-        // aabb slow path: terms within a group have differing coeff or
-        // real_phase, so the direct asign*bsign formula doesn't apply.
-        for(const auto& g : aabb_slow_groups)
-            process_standard_group(g);
-
-        for(const auto& g : bbbb_groups)
-            process_standard_group(g);
-
-        // other_groups is supposed to be empty. Kept here for safety.
-        for(const auto& g : other_groups)
-            process_standard_group(g);
     }
 
     sort_paired(cols, data);

--- a/fulqrum/core/src/matvec2.hpp
+++ b/fulqrum/core/src/matvec2.hpp
@@ -12,6 +12,7 @@
  * that they have been altered from the originals.
  */
 #pragma once
+#include <algorithm>
 #include <array>
 #include <complex>
 #include <cstddef>
@@ -59,6 +60,43 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
     std::size_t kk;
     const auto* bitsets = subspace.get_bitsets();
 
+    // See csrlike_builder2.hpp for the rationale.
+    // The flatten is O(num_groups) and negligible vs the matvec.
+    std::vector<width_t> _flat_inds;
+    std::vector<std::size_t> _inds_offsets;
+    flatten_offdiag_inds(group_offdiag_inds, _flat_inds, _inds_offsets);
+    const width_t* __restrict flat_inds = _flat_inds.data();
+    const std::size_t* __restrict inds_offsets = _inds_offsets.data();
+    auto gview = [&](std::size_t g) -> GroupIndsView {
+        const std::size_t off = inds_offsets[g];
+        return GroupIndsView{flat_inds + off, inds_offsets[g + 1] - off};
+    };
+
+    // See csrlike_builder2.hpp for the rationale.
+    const std::size_t _ladder_len = static_cast<std::size_t>(num_groups) * ladder_offset + 1;
+    const bool _ladder_fits = terms.size() <= UINT32_MAX;
+    std::vector<std::uint32_t> _ladder32;
+    if(_ladder_fits)
+    {
+        _ladder32.resize(_ladder_len);
+        for(std::size_t i = 0; i < _ladder_len; ++i)
+            _ladder32[i] = static_cast<std::uint32_t>(group_ladder_ptrs[i]);
+    }
+    const std::uint32_t* __restrict ladder32 = _ladder32.data();
+    auto ladder = [&](std::size_t idx) -> std::size_t {
+        return _ladder_fits ? static_cast<std::size_t>(ladder32[idx]) : group_ladder_ptrs[idx];
+    };
+
+    std::size_t BLK = 128;
+    if(const char* _blk_env = std::getenv("FQ_BLK"))
+    {
+        long _blk = std::atol(_blk_env);
+        if(_blk > 0)
+            BLK = static_cast<std::size_t>(_blk);
+    }
+    const std::size_t rsb_w = width; // one uint8 per qubit
+    const std::size_t num_blocks = (subspace_dim + BLK - 1) / BLK;
+
     // Categorize groups into buckets based on offdiag indices (mirror of
     // csrlike_builder2): aa / aaaa / bb / bbbb / aabb / other.  half_width
     // splits the bitset into the alpha (lower) and beta (upper) sectors.
@@ -72,7 +110,7 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
     const width_t half_width = width / 2;
     for(std::size_t g = 0; g < num_groups; g++)
     {
-        const auto& inds = group_offdiag_inds[g];
+        const GroupIndsView inds = gview(g);
         const std::size_t ind_size = inds.size();
 
         if(ind_size == 2)
@@ -167,14 +205,13 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
         }
     }
 
-    // ---- aabb fast-path prefilter setup -------------------------------------
+    // aabb fast-path prefilter setup
     // See csrlike_builder2.hpp for details.
     auto region_hash = [&](const boost::dynamic_bitset<std::size_t>& bs,
                            width_t lo,
                            width_t hi,
                            width_t fa,
                            width_t fb) -> std::uint64_t {
-
         const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
         const std::size_t hi_blk = static_cast<std::size_t>(hi - 1) >> BLOCK_EXPONENT;
         const std::size_t n_blk = hi_blk - lo_blk + 1;
@@ -225,7 +262,7 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
         std::unordered_map<std::uint32_t, std::uint32_t> b_pair_id;
         for(const auto& g : aabb_fast_groups)
         {
-            const auto& inds = group_offdiag_inds[g];
+            const GroupIndsView inds = gview(g);
             const width_t ap0 = inds[0], ap1 = inds[1], bp0 = inds[2], bp1 = inds[3];
             const std::uint32_t ak = (std::uint32_t(ap0) << 16) | ap1;
             const std::uint32_t bk = (std::uint32_t(bp0) << 16) | bp1;
@@ -278,117 +315,84 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
         // Take care of off-diagonal terms
         if(num_terms)
         {
+            // Per-thread scratch, reused across blocks (no per-block realloc).
+            std::vector<uint8_t> rsb_buf;
+            std::vector<char> alpha_ok(num_a_pairs);
+            std::vector<char> beta_ok(num_b_pairs);
+            boost::dynamic_bitset<std::size_t> col_vec;
+
+            // see csrlike_builder2.hpp for details.
 #pragma omp for schedule(dynamic)
-            for(kk = 0; kk < subspace_dim; kk++)
+            for(std::size_t blk = 0; blk < num_blocks; ++blk)
             {
-                const boost::dynamic_bitset<size_t>& row = bitsets[kk].first;
+                const std::size_t r0 = blk * BLK;
+                const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
+                const std::size_t bn = r1 - r0;
 
-                boost::dynamic_bitset<std::size_t> col_vec;
-                T val;
-                const OperatorTerm_t* term;
-                std::size_t group_int_start, group_int_stop;
-                std::size_t idx;
-                std::size_t* col_ptr;
-                std::size_t col_idx;
-                unsigned int row_int;
-                const std::vector<width_t>* group_inds;
-
-                std::vector<uint8_t> row_set_bits(row.size(), 0);
-                bitset_to_bitvec(row, row_set_bits);
-
-                // Per-row aabb prefilter (distinct pair validity).
-                std::vector<char> alpha_ok(num_a_pairs);
-                std::vector<char> beta_ok(num_b_pairs);
-
-                auto range_parity = [&](width_t lo, width_t hi) -> std::size_t {
-                    if(lo >= hi)
+                // row_set_bits for every row in the block, contiguous.
+                rsb_buf.assign(bn * rsb_w, 0);
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                {
+                    const boost::dynamic_bitset<std::size_t>& row =
+                        bitsets[r0 + row_in_block].first;
+                    uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
+                    for(std::size_t b = 0; b < row.num_blocks(); ++b)
                     {
-                        return 0;
-                    }
-                    const width_t last = hi - 1; // inclusive last bit
-                    const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
-                    const std::size_t hi_blk = static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
-                    const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
-                    const std::size_t hi_mask =
-                        ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
-
-                    std::size_t acc;
-                    if(lo_blk == hi_blk)
-                    {
-                        acc = row.m_bits[lo_blk] & lo_mask & hi_mask;
-                    }
-                    else
-                    {
-                        acc = row.m_bits[lo_blk] & lo_mask;
-                        for(std::size_t b = lo_blk + 1; b < hi_blk; b++)
+                        std::size_t bits = row.m_bits[b];
+                        while(bits != 0)
                         {
-                            acc ^= row.m_bits[b];
+                            int r = __builtin_ctzll(bits);
+                            dst[b * BITS_PER_BLOCK + r] = 1;
+                            bits &= bits - 1;
                         }
-                        acc ^= row.m_bits[hi_blk] & hi_mask;
                     }
-                    return static_cast<std::size_t>(
-                        __builtin_parityll(static_cast<unsigned long long>(acc)));
-                };
+                }
 
-                // out_vec[kk] is owned by this iteration only -> no mutex.
-                auto emit = [&](std::size_t cidx, const T& v) {
-                    out_vec[kk] += (v * in_vec[cidx]);
-                };
-
-                // Standard per-group path: validity check -> ladder lookup ->
-                // col flip -> subspace lookup -> term loop -> emit.  Shared by
-                // aa, aaaa, bb, bbbb, aabb_slow and other_groups.
-                auto process_standard_group = [&](std::size_t g) {
-                    group_inds = &group_offdiag_inds[g];
+                // Standard per-group path for one (group g, row_in_block) pair.
+                // out_vec[r0+row_in_block] is owned by this block/thread -> no mutex.
+                auto process_standard_group = [&](std::size_t g, std::size_t row_in_block) {
+                    const GroupIndsView group_inds = gview(g);
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
 
                     // Hamming weight check.
-                    // Flip pos must have equal number of 1s and 0s.
-                    const width_t _p = (*group_inds)[0];
-                    const width_t _q = (*group_inds)[1];
-
-                    if(group_inds->size() == 2)
+                    const width_t _p = group_inds[0];
+                    const width_t _q = group_inds[1];
+                    if(group_inds.size() == 2)
                     {
                         if(row_set_bits[_p] == row_set_bits[_q])
-                        {
                             return;
-                        }
                     }
-                    else if(group_inds->size() == 4)
+                    else if(group_inds.size() == 4)
                     {
-                        const width_t _r = (*group_inds)[2];
-                        const width_t _s = (*group_inds)[3];
+                        const width_t _r = group_inds[2];
+                        const width_t _s = group_inds[3];
                         if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] +
                                row_set_bits[_s] !=
                            2)
-                        {
                             return;
-                        }
                     }
 
-                    row_int = bitset_ladder_int(
-                        row_set_bits.data(), group_inds->data(), group_rowint_length[g]);
-                    group_int_start = group_ladder_ptrs[g * ladder_offset + row_int];
-                    group_int_stop = group_ladder_ptrs[g * ladder_offset + row_int + 1];
-
+                    const unsigned int row_int =
+                        bitset_ladder_int(row_set_bits, group_inds.data(), group_rowint_length[g]);
+                    const std::size_t group_int_start = ladder(g * ladder_offset + row_int);
+                    const std::size_t group_int_stop = ladder(g * ladder_offset + row_int + 1);
                     if(group_int_start >= group_int_stop)
-                    {
                         return;
-                    }
 
+                    const boost::dynamic_bitset<std::size_t>& row =
+                        bitsets[r0 + row_in_block].first;
                     col_vec = row;
-                    flip_bits(col_vec, group_inds->data(), group_inds->size());
+                    flip_bits(col_vec, group_inds.data(), group_inds.size());
 
-                    col_ptr = subspace.get_ptr(col_vec);
+                    std::size_t* col_ptr = subspace.get_ptr(col_vec);
                     if(col_ptr == nullptr)
-                    {
                         return;
-                    }
-                    col_idx = *col_ptr;
+                    const std::size_t col_idx = *col_ptr;
 
-                    val = 0;
-                    for(idx = group_int_start; idx < group_int_stop; idx++)
+                    T val = 0;
+                    for(std::size_t idx = group_int_start; idx < group_int_stop; idx++)
                     {
-                        term = &terms[idx];
+                        const OperatorTerm_t* term = &terms[idx];
                         if(passes_proj_validation(term, row))
                         {
                             accum_element(row,
@@ -403,104 +407,132 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
                     }
 
                     if(std::abs(val) > ATOL)
-                    {
-                        emit(col_idx, val);
-                    }
+                        out_vec[r0 + row_in_block] += (val * in_vec[col_idx]);
                 };
 
                 for(const auto& g : aa_groups)
-                    process_standard_group(g);
+                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                        process_standard_group(g, row_in_block);
                 for(const auto& g : aaaa_groups)
-                    process_standard_group(g);
+                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                        process_standard_group(g, row_in_block);
                 for(const auto& g : bb_groups)
-                    process_standard_group(g);
+                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                        process_standard_group(g, row_in_block);
 
-                for(std::size_t i = 0; i < num_a_pairs; ++i)
+                // aabb fast path, ROW-major within the block to preserve the
+                // per-row alpha/beta prefilter skip.
+                if(!aabb_fast_groups.empty())
                 {
-                    const width_t p0 = a_pairs[i][0];
-                    const width_t p1 = a_pairs[i][1];
-                    if(row_set_bits[p0] == row_set_bits[p1])
+                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
                     {
-                        alpha_ok[i] = 0;
-                        continue;
+                        const boost::dynamic_bitset<std::size_t>& row =
+                            bitsets[r0 + row_in_block].first;
+                        const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+
+                        auto range_parity = [&](width_t lo, width_t hi) -> std::size_t {
+                            if(lo >= hi)
+                                return 0;
+                            const width_t last = hi - 1; // inclusive last bit
+                            const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
+                            const std::size_t hi_blk =
+                                static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
+                            const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
+                            const std::size_t hi_mask =
+                                ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
+                            std::size_t acc;
+                            if(lo_blk == hi_blk)
+                            {
+                                acc = row.m_bits[lo_blk] & lo_mask & hi_mask;
+                            }
+                            else
+                            {
+                                acc = row.m_bits[lo_blk] & lo_mask;
+                                for(std::size_t b = lo_blk + 1; b < hi_blk; b++)
+                                    acc ^= row.m_bits[b];
+                                acc ^= row.m_bits[hi_blk] & hi_mask;
+                            }
+                            return static_cast<std::size_t>(
+                                __builtin_parityll(static_cast<unsigned long long>(acc)));
+                        };
+
+                        for(std::size_t i = 0; i < num_a_pairs; ++i)
+                        {
+                            const width_t p0 = a_pairs[i][0];
+                            const width_t p1 = a_pairs[i][1];
+                            if(row_set_bits[p0] == row_set_bits[p1])
+                            {
+                                alpha_ok[i] = 0;
+                                continue;
+                            }
+                            alpha_ok[i] =
+                                alpha_half_hashes.contains(region_hash(row, 0, half_width, p0, p1));
+                        }
+                        for(std::size_t j = 0; j < num_b_pairs; ++j)
+                        {
+                            const width_t p0 = b_pairs[j][0];
+                            const width_t p1 = b_pairs[j][1];
+                            if(row_set_bits[p0] == row_set_bits[p1])
+                            {
+                                beta_ok[j] = 0;
+                                continue;
+                            }
+                            beta_ok[j] = beta_half_hashes.contains(
+                                region_hash(row, half_width, width, p0, p1));
+                        }
+
+                        for(std::size_t i = 0; i < num_a_pairs; ++i)
+                        {
+                            if(!alpha_ok[i])
+                                continue;
+                            const width_t ap0 = a_pairs[i][0];
+                            const width_t ap1 = a_pairs[i][1];
+                            for(const auto& e : aabb_by_alpha[i])
+                            {
+                                if(!beta_ok[e.b_id])
+                                    continue;
+                                const GroupIndsView group_inds = gview(e.g);
+                                const width_t bp0 = group_inds[2];
+                                const width_t bp1 = group_inds[3];
+
+                                const unsigned int row_int = bitset_ladder_int(
+                                    row_set_bits, group_inds.data(), group_rowint_length[e.g]);
+                                const std::size_t group_int_start =
+                                    ladder(e.g * ladder_offset + row_int);
+                                const std::size_t group_int_stop =
+                                    ladder(e.g * ladder_offset + row_int + 1);
+                                if(group_int_start >= group_int_stop)
+                                    continue;
+
+                                col_vec = row;
+                                flip_bits(col_vec, group_inds.data(), group_inds.size());
+                                std::size_t* col_ptr = subspace.get_ptr(col_vec);
+                                if(col_ptr == nullptr)
+                                    continue;
+                                const std::size_t col_idx = *col_ptr;
+
+                                const std::size_t aabb_parity =
+                                    range_parity(ap0 + 1, ap1) ^ range_parity(bp0 + 1, bp1);
+                                double sign = aabb_parity ? -1.0 : 1.0;
+                                T val = aabb_direct[e.g] * static_cast<T>(sign);
+
+                                if(std::abs(val) > ATOL)
+                                    out_vec[r0 + row_in_block] += (val * in_vec[col_idx]);
+                            }
+                        }
                     }
-                    alpha_ok[i] =
-                        alpha_half_hashes.contains(region_hash(row, 0, half_width, p0, p1));
                 }
-                for(std::size_t j = 0; j < num_b_pairs; ++j)
-                {
-                    const width_t p0 = b_pairs[j][0];
-                    const width_t p1 = b_pairs[j][1];
-                    if(row_set_bits[p0] == row_set_bits[p1])
-                    {
-                        beta_ok[j] = 0;
-                        continue;
-                    }
-                    beta_ok[j] =
-                        beta_half_hashes.contains(region_hash(row, half_width, width, p0, p1));
-                }
 
-                for(std::size_t i = 0; i < num_a_pairs; ++i)
-                {
-                    if(!alpha_ok[i])
-                    {
-                        continue;
-                    }
-                    const width_t ap0 = a_pairs[i][0];
-                    const width_t ap1 = a_pairs[i][1];
-                    for(const auto& e : aabb_by_alpha[i])
-                    {
-                        if(!beta_ok[e.b_id])
-                        {
-                            continue;
-                        }
-                        group_inds = &group_offdiag_inds[e.g];
-                        const width_t bp0 = (*group_inds)[2];
-                        const width_t bp1 = (*group_inds)[3];
-
-                        row_int = bitset_ladder_int(
-                            row_set_bits.data(), group_inds->data(), group_rowint_length[e.g]);
-                        group_int_start = group_ladder_ptrs[e.g * ladder_offset + row_int];
-                        group_int_stop = group_ladder_ptrs[e.g * ladder_offset + row_int + 1];
-                        if(group_int_start >= group_int_stop)
-                        {
-                            continue;
-                        }
-
-                        col_vec = row;
-                        flip_bits(col_vec, group_inds->data(), group_inds->size());
-                        col_ptr = subspace.get_ptr(col_vec);
-                        if(col_ptr == nullptr)
-                        {
-                            continue;
-                        }
-                        col_idx = *col_ptr;
-
-                        const std::size_t aabb_parity =
-                            range_parity(ap0 + 1, ap1) ^ range_parity(bp0 + 1, bp1);
-                        double sign = aabb_parity ? -1.0 : 1.0;
-
-                        val = aabb_direct[e.g] * static_cast<T>(sign);
-
-                        if(std::abs(val) > ATOL)
-                        {
-                            emit(col_idx, val);
-                        }
-                    }
-                }
-
-                // aabb slow path: terms within a group have differing coeff or
-                // real_phase, so the direct asign*bsign formula doesn't apply.
                 for(const auto& g : aabb_slow_groups)
-                    process_standard_group(g);
-
+                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                        process_standard_group(g, row_in_block);
                 for(const auto& g : bbbb_groups)
-                    process_standard_group(g);
-
-                // other_groups is supposed to be empty. Kept here for safety.
+                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                        process_standard_group(g, row_in_block);
                 for(const auto& g : other_groups)
-                    process_standard_group(g);
-            } // end for-loop over rows
+                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                        process_standard_group(g, row_in_block);
+            } // end for-loop over blocks
         } // end if num_terms
     } // end parallel region
 } // end matvec

--- a/fulqrum/core/src/offdiag_grouping.hpp
+++ b/fulqrum/core/src/offdiag_grouping.hpp
@@ -13,9 +13,60 @@
  */
 #pragma once
 #include "base.hpp"
+#include "constants.hpp"
 #include <algorithm>
+#include <cstddef>
 #include <cstdlib>
 #include <vector>
+
+// A lightweight, read-only window onto one group's offdiag indices.
+//
+// A GroupIndsView is just a pointer + a length. It owns nothing and copies
+// nothing and behaves like a tiny read-only array: use size() for how many indices
+// the group has, and view[i] to read the i-th one. Underlying storage is contiguous.
+struct GroupIndsView
+{
+    const width_t* __restrict p; // start of this group's indices in the flat array
+    std::size_t n; // how many indices this group has (e.g. 2 or 4)
+    std::size_t size() const
+    {
+        return n;
+    }
+    width_t operator[](std::size_t i) const
+    {
+        return p[i];
+    } // read the i-th index
+    const width_t* data() const
+    {
+        return p;
+    } // raw pointer to the slice
+};
+
+// Flatten group_offdiag_inds (which is a std::vector<std::vector<width_t>>
+// each inner vector is scattered across the heap, making access inefficient) into
+// a CSR-like structure: one contiguous values array plus CSR offsets.
+// The flattened structure's "offsets" resemble CSR's "indptr" and "flat_inds"
+// resembles CSR's "data". It is CSR-like because full CSR also has a column-"indices",
+// which we do not need.
+// Group g occupies flat_inds[offsets[g], offsets[g+1]).
+// Iterating groups then touches contiguous memory instead of chasing pointers
+// in the previous 2D vector structure.
+inline void flatten_offdiag_inds(const std::vector<std::vector<width_t>>& group_offdiag_inds,
+                                 std::vector<width_t>& flat_inds,
+                                 std::vector<std::size_t>& offsets)
+{
+    const std::size_t num_groups = group_offdiag_inds.size();
+    offsets.resize(num_groups + 1);
+    offsets[0] = 0;
+    for(std::size_t g = 0; g < num_groups; ++g)
+        offsets[g + 1] = offsets[g] + group_offdiag_inds[g].size();
+    flat_inds.resize(offsets[num_groups]);
+    for(std::size_t g = 0; g < num_groups; ++g)
+    {
+        const auto& v = group_offdiag_inds[g];
+        std::copy(v.begin(), v.end(), flat_inds.begin() + offsets[g]);
+    }
+}
 
 /**
  * Constructs a vector of max offdiagonal group indices.

--- a/fulqrum/core/src/version.hpp
+++ b/fulqrum/core/src/version.hpp
@@ -13,5 +13,5 @@
  */
 #pragma once
 
-#define FULQRUM_VERSION "0.2.3"
+#define FULQRUM_VERSION "0.2.4"
 #define JSON_VERSION "1.1"


### PR DESCRIPTION
Brings three changes in the type 2 paths (csr2, matvec2, and csrlike_builder2):
1. Changes default ladder width from 4 to 2, but makes it user tunable via env var `FQ_LADDER_WIDTH`.
    - Smaller ladder width makes the group ladder ptrs table leaner: better for cache efficiency.
2. Flattens the `group_offdiag_indices` from a 2D vector to a contiguous CSR-like structure.
    - The inner vectors in a 2D vec can be scattered across the heap.
    - The flat structure is contiguous in memory and has favorable access pattern. Empirically it shows ~20% speed-up, but varies from platform to platform.
3. Changes the order of loop iterations.
    - Now it is group middle x block of rows inner. Each group g (-> a chunk of group_ladder_ptrs) processes a small block of rows. All rows in the block reuses the chunk of group_ladder_ptrs, significantly reducing cache miss rates. Shows significant bump is speed; ~2X at cases (along with 1 and 2).
    - The number of rows in the block is user tunable via `FQ_BLK` env var, although 128 rows in a block is a reasonable middle ground.

No public APIs have changed.

Type 1 paths do not have these optimizations yet although there is nothing blocking them to have the cache friendly structures. 