### PR TITLE
Add Primme to unittests

### DIFF
--- a/fulqrum/test/test_eigen.py
+++ b/fulqrum/test/test_eigen.py
@@ -17,6 +17,7 @@ from fulqrum import QubitOperator, Subspace, SubspaceHamiltonian
 from fulqrum.utils import kron_str
 
 import scipy.sparse.linalg as spla
+import primme
 
 
 def grab_subspace(A, rows):
@@ -48,14 +49,24 @@ def test_eigen1():
     subspace_dict = {bin(rr)[2:].zfill(H.width): 1 for rr in rows}
 
     ans_evals, _ = spla.eigsh(B, k=2, which="SA", v0=np.ones(B.shape[0]))
+    # eigenenergies are not guarenteed to be sorted low->high here
+    ans_evals = np.sort(ans_evals)
 
     S = Subspace([list(subspace_dict.keys())])
     Hsub = SubspaceHamiltonian(H, S)
     evals, evecs = spla.eigsh(Hsub, k=2, which="SA", v0=np.ones(len(S)))
-    assert np.allclose(ans_evals, evals)
+    assert np.allclose(ans_evals, np.sort(evals))
     for kk in range(2):
         assert (
             np.linalg.norm(B.dot(evecs[:, kk]) - evals[kk] * evecs[:, kk], np.inf)
+            < 1e-13
+        )
+
+    evals2, evecs2 = primme.eigsh(Hsub, k=2, which="SA", v0=np.ones((len(S), 1)))
+    assert np.allclose(ans_evals, evals2)
+    for kk in range(2):
+        assert (
+            np.linalg.norm(B.dot(evecs2[:, kk]) - evals2[kk] * evecs2[:, kk], np.inf)
             < 1e-13
         )
 
@@ -63,7 +74,7 @@ def test_eigen1():
     S = Subspace([list(subspace_dict.keys())], use_all_bitset_blocks=False)
     Hsub = SubspaceHamiltonian(H, S)
     evals, evecs = spla.eigsh(Hsub, k=2, which="SA", v0=np.ones(len(S)))
-    assert np.allclose(ans_evals, evals)
+    assert np.allclose(ans_evals, np.sort(evals))
     for kk in range(2):
         assert (
             np.linalg.norm(B.dot(evecs[:, kk]) - evals[kk] * evecs[:, kk], np.inf)
@@ -102,6 +113,13 @@ def test_eigen2():
             np.linalg.norm(B.dot(evecs[:, kk]) - evals[kk] * evecs[:, kk], np.inf)
             < 1e-13
         )
+    evals2, evecs2 = primme.eigsh(Hsub, k=2, which="SA", v0=np.ones((len(S), 1)))
+    assert np.allclose(ans_evals, evals2)
+    for kk in range(2):
+        assert (
+            np.linalg.norm(B.dot(evecs2[:, kk]) - evals2[kk] * evecs2[:, kk], np.inf)
+            < 1e-13
+        )
 
     # hashing only the first (`bitset.m_bits[0]`) bitset block
     S = Subspace([list(subspace_dict.keys())], use_all_bitset_blocks=False)
@@ -111,6 +129,13 @@ def test_eigen2():
     for kk in range(2):
         assert (
             np.linalg.norm(B.dot(evecs[:, kk]) - evals[kk] * evecs[:, kk], np.inf)
+            < 1e-13
+        )
+    evals2, evecs2 = primme.eigsh(Hsub, k=2, which="SA", v0=np.ones((len(S), 1)))
+    assert np.allclose(ans_evals, evals2)
+    for kk in range(2):
+        assert (
+            np.linalg.norm(B.dot(evecs2[:, kk]) - evals2[kk] * evecs2[:, kk], np.inf)
             < 1e-13
         )
 
@@ -134,16 +159,25 @@ def test_eigen3():
     B = grab_subspace(A, rows)
 
     subspace_dict = {bin(rr)[2:].zfill(H.width): 1 for rr in rows}
-
-    ans_evals, _ = spla.eigsh(B, k=3, which="SA")
-
     S = Subspace([list(subspace_dict.keys())])
+
+    ans_evals, _ = spla.eigsh(B, k=3, which="SA", v0=np.ones(len(S)))
+    # eigenenergies are not guarenteed to be sorted low->high here
+    # ans_evals = np.sort(ans_evals)
+
     Hsub = SubspaceHamiltonian(H, S)
     evals, evecs = spla.eigsh(Hsub, k=3, which="SA")
     assert np.allclose(ans_evals, evals)
     for kk in range(3):
         assert (
             np.linalg.norm(B.dot(evecs[:, kk]) - evals[kk] * evecs[:, kk], np.inf)
+            < 1e-13
+        )
+    evals2, evecs2 = primme.eigsh(Hsub, k=3, which="SA", v0=np.ones((len(S), 1)))
+    assert np.allclose(ans_evals, evals2)
+    for kk in range(3):
+        assert (
+            np.linalg.norm(B.dot(evecs2[:, kk]) - evals2[kk] * evecs2[:, kk], np.inf)
             < 1e-13
         )
 
@@ -155,6 +189,14 @@ def test_eigen3():
     for kk in range(3):
         assert (
             np.linalg.norm(B.dot(evecs[:, kk]) - evals[kk] * evecs[:, kk], np.inf)
+            < 1e-13
+        )
+
+    evals2, evecs2 = primme.eigsh(Hsub, k=3, which="SA", v0=np.ones((len(S), 1)))
+    assert np.allclose(ans_evals, evals2)
+    for kk in range(3):
+        assert (
+            np.linalg.norm(B.dot(evecs2[:, kk]) - evals2[kk] * evecs2[:, kk], np.inf)
             < 1e-13
         )
 
@@ -192,6 +234,14 @@ def test_eigen4():
             < 1e-13
         )
 
+    evals2, evecs2 = primme.eigsh(Hsub, k=3, which="SA", v0=np.ones((len(S), 1)))
+    assert np.allclose(ans_evals, evals2)
+    for kk in range(3):
+        assert (
+            np.linalg.norm(B.dot(evecs2[:, kk]) - evals2[kk] * evecs2[:, kk], np.inf)
+            < 1e-11  # Error a bit larger in this case
+        )
+
     # hashing only the first (`bitset.m_bits[0]`) bitset block
     S = Subspace([list(subspace_dict.keys())], use_all_bitset_blocks=False)
     Hsub = SubspaceHamiltonian(H, S)
@@ -201,6 +251,14 @@ def test_eigen4():
         assert (
             np.linalg.norm(B.dot(evecs[:, kk]) - evals[kk] * evecs[:, kk], np.inf)
             < 1e-13
+        )
+
+    evals2, evecs2 = primme.eigsh(Hsub, k=3, which="SA", v0=np.ones((len(S), 1)))
+    assert np.allclose(ans_evals, evals2)
+    for kk in range(3):
+        assert (
+            np.linalg.norm(B.dot(evecs2[:, kk]) - evals2[kk] * evecs2[:, kk], np.inf)
+            < 1e-11  # Error a bit larger in this case
         )
 
 
@@ -221,6 +279,7 @@ def test_eigen5():
     v0 = np.ones(len(rows), dtype=float)
     B = grab_subspace(A, rows)
     ans_evals, ans_evecs = spla.eigsh(B, k=num_evals, which="SA", v0=v0)
+    ans_evals = np.sort(ans_evals)  # scipy not sorting low -> high
 
     width = len(obs[0])
     H = QubitOperator(width)
@@ -232,7 +291,7 @@ def test_eigen5():
     S = Subspace([list(subspace_dict.keys())])
     Hsub = SubspaceHamiltonian(H, S)
     evals, evecs = spla.eigsh(Hsub, k=num_evals, which="SA", v0=v0)
-    assert np.allclose(ans_evals, evals)
+    assert np.allclose(ans_evals, np.sort(evals))
     for kk in range(num_evals):
         assert (
             np.linalg.norm(B.dot(evecs[:, kk]) - evals[kk] * evecs[:, kk], np.inf)
@@ -243,7 +302,7 @@ def test_eigen5():
     S = Subspace([list(subspace_dict.keys())], use_all_bitset_blocks=False)
     Hsub = SubspaceHamiltonian(H, S)
     evals, evecs = spla.eigsh(Hsub, k=num_evals, which="SA", v0=v0)
-    assert np.allclose(ans_evals, evals)
+    assert np.allclose(ans_evals, np.sort(evals))
     for kk in range(num_evals):
         assert (
             np.linalg.norm(B.dot(evecs[:, kk]) - evals[kk] * evecs[:, kk], np.inf)

--- a/fulqrum/test/test_eigen_H2.py
+++ b/fulqrum/test/test_eigen_H2.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import numpy as np
 import scipy.linalg as la
 import scipy.sparse.linalg as spla
+import primme
 
 from fulqrum import FermionicOperator, Subspace, SubspaceHamiltonian
 from fulqrum.utils import qubitoperator_to_matrix
@@ -60,6 +61,11 @@ def test_full_dist_h2_eigen():
     assert np.allclose(evals, GROUND_ENERGY)
     assert np.allclose(evecs.ravel(), ANS_EVECS[:, 0])
 
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(Hsub, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY)
+
 
 def test_partial_dist_h2_eigen1():
     """Test subspace that overlaps with ground state still works"""
@@ -91,6 +97,11 @@ def test_partial_dist_h2_eigen1():
     assert abs(ans_dict["1010"] - GROUND_DIST["1010"]) < 1e-14
     assert abs(ans_dict["0101"] - GROUND_DIST["0101"]) < 1e-14
 
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(Hsub, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY)
+
 
 def test_partial_dist_h2_eigen2():
     """Test subspace that overlaps with ground state still works"""
@@ -119,6 +130,11 @@ def test_partial_dist_h2_eigen2():
     ans_dict = Hsub.interpret_vector(evecs)
     assert abs(ans_dict["1010"] - GROUND_DIST["1010"]) < 1e-14
     assert abs(ans_dict["0101"] - GROUND_DIST["0101"]) < 1e-14
+
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(Hsub, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY)
 
 
 def test_full_dist_h2_eigen_csr_linearoperator():
@@ -152,6 +168,11 @@ def test_full_dist_h2_eigen_csr_linearoperator():
     assert np.allclose(evals, GROUND_ENERGY)
     assert np.allclose(evecs.ravel(), ANS_EVECS[:, 0])
 
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(M, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY)
+
 
 def test_full_dist_h2_eigen_csr_linearoperator_fast():
     """Test full space solution against exact for CSR linearoperator fast"""
@@ -183,6 +204,11 @@ def test_full_dist_h2_eigen_csr_linearoperator_fast():
     assert evecs.dtype == float
     assert np.allclose(evals, GROUND_ENERGY)
     assert np.allclose(evecs.ravel(), ANS_EVECS[:, 0])
+
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(M, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY)
 
 
 def test_proj_indices_set():

--- a/fulqrum/test/test_eigen_H20.py
+++ b/fulqrum/test/test_eigen_H20.py
@@ -15,6 +15,7 @@
 from pathlib import Path
 import numpy as np
 import scipy.sparse.linalg as spla
+import primme
 
 from fulqrum import FermionicOperator, Subspace, SubspaceHamiltonian
 
@@ -43,6 +44,11 @@ def test_full_dist_h20_eigenenergy_matrix_free():
     evals, _ = spla.eigsh(Hsub, k=1, which="SA", v0=np.ones(len(S), dtype=float))
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
 
+    evals2, _ = primme.eigsh(
+        Hsub, k=1, which="SA", v0=np.ones((len(S), 1), dtype=float)
+    )
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
+
 
 def test_full_dist_h20_eigenenergy_csr():
     """Test full space solution against exact for CSR matrix"""
@@ -66,6 +72,9 @@ def test_full_dist_h20_eigenenergy_csr():
 
     evals, _ = spla.eigsh(M, k=1, which="SA", v0=np.ones(len(S), dtype=float))
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
+
+    evals2, _ = primme.eigsh(M, k=1, which="SA", v0=np.ones((len(S), 1), dtype=float))
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
 
 
 def test_full_dist_h20_eigenenergy_csr_linearoperator():
@@ -91,6 +100,9 @@ def test_full_dist_h20_eigenenergy_csr_linearoperator():
     evals, _ = spla.eigsh(M, k=1, which="SA", v0=np.ones(len(S), dtype=float))
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
 
+    evals2, _ = primme.eigsh(M, k=1, which="SA", v0=np.ones((len(S), 1), dtype=float))
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
+
 
 def test_full_dist_h20_eigenenergy_csr_linearoperator_fast():
     """Test full space solution against exact for CSR linearoperator fast"""
@@ -114,6 +126,9 @@ def test_full_dist_h20_eigenenergy_csr_linearoperator_fast():
     assert M.matrix.dtype == float
     evals, _ = spla.eigsh(M, k=1, which="SA", v0=np.ones(len(S), dtype=float))
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
+
+    evals2, _ = primme.eigsh(M, k=1, which="SA", v0=np.ones((len(S), 1), dtype=float))
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
 
 
 def test_proj_indices_set():

--- a/fulqrum/test/test_eigen_LiH.py
+++ b/fulqrum/test/test_eigen_LiH.py
@@ -15,6 +15,7 @@
 from pathlib import Path
 import numpy as np
 import scipy.sparse.linalg as spla
+import primme
 
 import fulqrum as fq
 
@@ -121,6 +122,11 @@ def test_full_dist_lih_eigen():
     assert evecs.dtype == float
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
 
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(Hsub, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
+
 
 def test_full_dist_lih_eigen_csr():
     """Test full space CSR solution against exact"""
@@ -150,6 +156,11 @@ def test_full_dist_lih_eigen_csr():
     evals, evecs = spla.eigsh(M, k=1, which="SA", v0=x0)
     assert evecs.dtype == float
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
+
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(M, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
 
 
 def test_full_dist_lih_eigen_csr_fast():
@@ -181,6 +192,11 @@ def test_full_dist_lih_eigen_csr_fast():
     assert evecs.dtype == float
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
 
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(M, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
+
 
 def test_grnd_dist_lih_eigen():
     """Test grnd state space solution against exact"""
@@ -202,6 +218,11 @@ def test_grnd_dist_lih_eigen():
     evals, evecs = spla.eigsh(Hsub, k=1, which="SA", v0=x0)
     assert evecs.dtype == float
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
+
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(Hsub, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
 
 
 def test_grnd_dist_lih_eigen_csr():
@@ -229,6 +250,11 @@ def test_grnd_dist_lih_eigen_csr():
     assert evecs.dtype == float
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
 
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(M, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
+
 
 def test_grnd_dist_lih_eigen_csr_fast():
     """Test grnd space CSR fast solution against exact"""
@@ -254,6 +280,11 @@ def test_grnd_dist_lih_eigen_csr_fast():
     evals, evecs = spla.eigsh(M, k=1, which="SA", v0=x0)
     assert evecs.dtype == float
     assert np.allclose(evals, GROUND_ENERGY, 1e-12)
+
+    x0p = np.ones((len(S), 1), dtype=float if OP.is_real() else complex)
+    evals2, evecs2 = primme.eigsh(M, k=1, which="SA", v0=x0p)
+    assert evecs2.dtype == float
+    assert np.allclose(evals2, GROUND_ENERGY, 1e-12)
 
 
 def test_proj_indices_set():


### PR DESCRIPTION
requires #74 
closes #75 

Adds PRIMME to the unit tests in the generic and chemistry-based eigen tests.