### PR TITLE
Speed up sorting routines and JW transform

### DIFF
--- a/fulqrum/core/fermi_operator.pyx
+++ b/fulqrum/core/fermi_operator.pyx
@@ -79,6 +79,7 @@ cdef class FermionicOperator():
                                 term.indices.push_back(inds[kk])
                                 ind = STR_TO_IND[op_str[kk]]
                                 term.values.push_back(ind)
+                                term.offdiag_structure += (inds[kk] + 1) * (ind > 2)
                         term.coeff = coeff
                 else:
                     term.coeff = 1
@@ -274,6 +275,25 @@ cdef class FermionicOperator():
             int
         """
         return self.oper.width
+
+    @cython.boundscheck(False)
+    def offdiag_structure_sort(self):
+        """Off-diagonal structures of each term in operator
+        """
+        self.oper.offdiag_structure_sort()
+        return self
+    
+    @cython.boundscheck(False)
+    def offdiag_structures(self):
+        """Off-diagonal structures of each term in operator
+        """
+        cdef size_t kk
+        if self.oper.terms.size() == 0:
+            raise FulqrumError('FermionicOperator has zero terms')
+        cdef unsigned int[::1] out = np.empty(self.oper.terms.size(), dtype=np.uint32)
+        for kk in range(self.oper.terms.size()):
+            out[kk] = self.oper.terms[kk].offdiag_structure
+        return np.asarray(out)
 
     @property
     def coeff(self):

--- a/fulqrum/core/fermi_operator.pyx
+++ b/fulqrum/core/fermi_operator.pyx
@@ -361,6 +361,11 @@ cdef class FermionicOperator():
                     out.append((IND_TO_STR[term.values[jj]], term.indices[jj]))
             return out
 
+    def weight_sort(self):
+        """In-place sort terms by their standard weight
+        """
+        self.oper.weight_sort()
+    
     @cython.boundscheck(False)
     def weights(self):
         """Weight of each term in the operator

--- a/fulqrum/core/fermi_operator.pyx
+++ b/fulqrum/core/fermi_operator.pyx
@@ -282,6 +282,20 @@ cdef class FermionicOperator():
         """
         self.oper.offdiag_structure_sort()
         return self
+
+    @cython.boundscheck(False)
+    def offdiag_structure_ptrs(self):
+        """Off-diagonal structures of each term in operator
+        """
+        cdef size_t kk
+        cdef vector[size_t] ptrs
+        if self.oper.terms.size() == 0:
+            raise FulqrumError('FermionicOperator has zero terms')
+        ptrs = self.oper.offdiag_structure_ptrs()
+        cdef size_t[::1] out = np.empty(ptrs.size(), dtype=np.uintp)
+        for kk in range(ptrs.size()):
+            out[kk] = ptrs[kk]
+        return np.asarray(out)
     
     @cython.boundscheck(False)
     def offdiag_structures(self):

--- a/fulqrum/core/fermi_operator.pyx
+++ b/fulqrum/core/fermi_operator.pyx
@@ -309,6 +309,18 @@ cdef class FermionicOperator():
             out[kk] = self.oper.terms[kk].offdiag_structure
         return np.asarray(out)
 
+    @cython.boundscheck(False)
+    def proj_structures(self):
+        """Off-diagonal structures of each term in operator
+        """
+        cdef size_t kk
+        if self.oper.terms.size() == 0:
+            raise FulqrumError('FermionicOperator has zero terms')
+        cdef unsigned int[::1] out = np.empty(self.oper.terms.size(), dtype=np.uint32)
+        for kk in range(self.oper.terms.size()):
+            out[kk] = self.oper.terms[kk].proj_structure
+        return np.asarray(out)
+
     @property
     def coeff(self):
         """Return the coeff for a single term or empty operator

--- a/fulqrum/core/fermi_operator.pyx
+++ b/fulqrum/core/fermi_operator.pyx
@@ -411,6 +411,13 @@ cdef class FermionicOperator():
         out.oper = self.oper.combine_repeat_indices()
         return out
 
+    def combine_repeated_terms(self, double atol=1e-12):
+        """In-place sort terms by their standard weight
+        """
+        cdef FermionicOperator out = FermionicOperator(self.width)
+        out.oper = self.oper.combine_repeated_terms(atol)
+        return out
+
     def extended_jw_transformation(self):
         """Jordan-Wigner transformation over extended alphabet
         from Fermionic -> Qubit operator

--- a/fulqrum/core/includes/base_header.pxi
+++ b/fulqrum/core/includes/base_header.pxi
@@ -96,7 +96,8 @@ cdef extern from "../src/base.hpp":
         void to_json(string, bool) except +
         FermionicOperator_t from_json(string) except +
         FermionicOperator_t combine_repeat_indices() nogil
-        FermionicOperator_t& weight_sort() nogil
+        FermionicOperator_t weight_sort() nogil
+        FermionicOperator_t combine_repeated_terms(double)
         QubitOperator_t extended_jw_transformation() nogil
 
     size_t max_offdiag_ptr_size(vector[size_t]&)

--- a/fulqrum/core/includes/base_header.pxi
+++ b/fulqrum/core/includes/base_header.pxi
@@ -31,6 +31,7 @@ cdef extern from "../src/base.hpp":
         int real_phase
         int group
         unsigned int offdiag_structure
+        unsigned int proj_structure
         void sort_term_data()
         void set_proj_indices()
         OperatorTerm_t()
@@ -86,8 +87,11 @@ cdef extern from "../src/base.hpp":
         double complex coeff
         vector[width_t] indices
         vector[unsigned char] values
+        vector[width_t] proj_indices
+        vector[width_t] proj_bits
         width_t offdiag_weight
         unsigned int offdiag_structure
+        unsigned int proj_structure
         void insertion_sort()
 
 

--- a/fulqrum/core/includes/base_header.pxi
+++ b/fulqrum/core/includes/base_header.pxi
@@ -92,9 +92,11 @@ cdef extern from "../src/base.hpp":
         width_t width
         vector[FermionicTerm_t] terms
         size_t size()
+        int weight_sorted
         void to_json(string, bool) except +
         FermionicOperator_t from_json(string) except +
         FermionicOperator_t combine_repeat_indices() nogil
+        FermionicOperator_t& weight_sort() nogil
         QubitOperator_t extended_jw_transformation() nogil
 
     size_t max_offdiag_ptr_size(vector[size_t]&)

--- a/fulqrum/core/includes/base_header.pxi
+++ b/fulqrum/core/includes/base_header.pxi
@@ -30,6 +30,7 @@ cdef extern from "../src/base.hpp":
         int extended
         int real_phase
         int group
+        unsigned int offdiag_structure
         void sort_term_data()
         void set_proj_indices()
         OperatorTerm_t()
@@ -85,6 +86,8 @@ cdef extern from "../src/base.hpp":
         double complex coeff
         vector[width_t] indices
         vector[unsigned char] values
+        width_t offdiag_weight
+        unsigned int offdiag_structure
         void insertion_sort()
 
 
@@ -97,8 +100,10 @@ cdef extern from "../src/base.hpp":
         FermionicOperator_t from_json(string) except +
         FermionicOperator_t combine_repeat_indices() nogil
         FermionicOperator_t weight_sort() nogil
+        FermionicOperator_t offdiag_structure_sort() nogil
         FermionicOperator_t combine_repeated_terms(double)
         QubitOperator_t extended_jw_transformation() nogil
+
 
     size_t max_offdiag_ptr_size(vector[size_t]&)
 

--- a/fulqrum/core/includes/base_header.pxi
+++ b/fulqrum/core/includes/base_header.pxi
@@ -103,6 +103,7 @@ cdef extern from "../src/base.hpp":
         FermionicOperator_t offdiag_structure_sort() nogil
         FermionicOperator_t combine_repeated_terms(double)
         QubitOperator_t extended_jw_transformation() nogil
+        vector[size_t] offdiag_structure_ptrs() nogil
 
 
     size_t max_offdiag_ptr_size(vector[size_t]&)

--- a/fulqrum/core/qubit_operator.pyx
+++ b/fulqrum/core/qubit_operator.pyx
@@ -98,6 +98,7 @@ cdef class QubitOperator():
                                 term.indices.push_back(inds[kk])
                                 ind = STR_TO_IND[op_str[kk]]
                                 term.values.push_back(ind)
+                                term.offdiag_structure += (inds[kk] + 1) * (ind > 2)
                         term.coeff = coeff
                 else:
                     term.coeff = 1
@@ -263,6 +264,18 @@ cdef class QubitOperator():
         """
 
         return self.oper.ladder_width
+
+    @cython.boundscheck(False)
+    def offdiag_structures(self):
+        """Off-diagonal structures of each term in operator
+        """
+        cdef size_t kk
+        if self.oper.terms.size() == 0:
+            raise FulqrumError('QubitOperator has zero terms')
+        cdef unsigned int[::1] out = np.empty(self.oper.terms.size(), dtype=np.uint32)
+        for kk in range(self.oper.terms.size()):
+            out[kk] = self.oper.terms[kk].offdiag_structure
+        return np.asarray(out)
 
     def copy(self):
         """Copy QubitOperator

--- a/fulqrum/core/qubit_operator.pyx
+++ b/fulqrum/core/qubit_operator.pyx
@@ -104,7 +104,7 @@ cdef class QubitOperator():
                     term.coeff = 1
                 term.sort_term_data()
                 set_offdiag_weight_and_phase(term)
-                set_proj_indices(term)
+                term.set_proj_indices()
                 set_extended_flag(term)
                 self.oper.terms.push_back(term)
 

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -32,6 +32,11 @@
 #include "oper_utils.hpp"
 
 
+// forward definitions
+void set_fermi_sorting_flags(FermionicOperator& oper, std::string kind);
+
+
+
 /** @struct FermionicOperator
  * @brief Data structure for each a qubit operator, i.e. a collection of 'words'
  *
@@ -44,6 +49,7 @@ typedef struct FermionicOperator
     width_t width;
     unsigned int combined = 0; // have the repeated operators indices been combined?
     int weight_sorted{0}; // Are the operator terms weight sorted
+    int structure_sorted{0}; // Are the operator terms sorted by (non-unique) off-diagonal structure?
     std::vector<FermionicTerm_t> terms;
     FermionicOperator() {}
     /**
@@ -270,7 +276,7 @@ typedef struct FermionicOperator
         out.combined = this->combined;
         return out;
     }
-       /**
+    /**
     * In-place sorting of terms by weight
     * 
     */
@@ -286,7 +292,27 @@ typedef struct FermionicOperator
             std::sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2)
                                                   {return term1.indices.size() < term2.indices.size();});
             #endif
-            this->weight_sorted = 1;
+            set_fermi_sorting_flags(*this, "weight");
+        }
+        return *this;
+    }
+    /**
+    * In-place sorting of terms by weight
+    * 
+    */
+    FermionicOperator& offdiag_structure_sort()
+    {
+        if(!(this->structure_sorted))
+        {
+            // sort by weight
+            #ifdef FQ_TBB
+            tbb::parallel_sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2)
+                                                  {return term1.offdiag_structure < term2.offdiag_structure;});
+            #else
+            std::sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2)
+                                                  {return term1.offdiag_structure < term2.offdiag_structure;});
+            #endif
+            set_fermi_sorting_flags(*this, "structure");
         }
         return *this;
     }
@@ -305,15 +331,15 @@ typedef struct FermionicOperator
         {
             return out;
         }
-        if(!this->weight_sorted)
+        if(!this->structure_sorted)
         {
-            this->weight_sort();
+            this->offdiag_structure_sort();
         }
-        std::vector<std::size_t> weight_ptrs;
-        set_weight_ptrs(terms, weight_ptrs);
+        std::vector<std::size_t> ptrs;
+        set_offdiag_structure_ptrs(terms, ptrs);
         std::vector<width_t> touched;
         touched.resize(this->size());
-        combine_terms(this->terms, out.terms, weight_ptrs, &touched[0], atol);
+        combine_terms(this->terms, out.terms, ptrs, &touched[0], atol);
         return out;
     }
     /**
@@ -389,3 +415,31 @@ typedef struct FermionicOperator
         return out.combine_repeated_terms();
     }
 } FermionicOperator_t;
+
+
+
+/**
+ * Set the FermionicOperator flags when performing sorting of various kinds
+ * 
+ * @param[in, out] oper The operator whose flags to set
+ * @param[in] kind Sting indicating the type of sorting that was performed
+ * 
+ * @throws Error if sorting type is not a valid kind
+ */
+inline void set_fermi_sorting_flags(FermionicOperator& oper, std::string kind)
+{
+    if(kind == "weight")
+    {
+        oper.weight_sorted = 1;
+        oper.structure_sorted = 0;
+    }
+    else if(kind == "structure")
+    {
+        oper.weight_sorted = 0;
+        oper.structure_sorted = 1;
+    }
+    else
+    {
+        throw std::runtime_error("Invalid sorting type.");
+    }
+}

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <boost/sort/pdqsort/pdqsort.hpp>
 #ifdef FQ_TBB
 #    include <oneapi/tbb/parallel_sort.h>
 #endif
@@ -292,7 +293,7 @@ typedef struct FermionicOperator
                     return term1.indices.size() < term2.indices.size();
                 });
 #else
-            std::sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+            boost::sort::pdqsort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
                 return term1.indices.size() < term2.indices.size();
             });
 #endif
@@ -315,7 +316,7 @@ typedef struct FermionicOperator
                     return term1.offdiag_structure < term2.offdiag_structure;
                 });
 #else
-            std::sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+            boost::sort::pdqsort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
                 return term1.offdiag_structure < term2.offdiag_structure;
             });
 #endif
@@ -428,11 +429,13 @@ typedef struct FermionicOperator
         std::size_t kk;
         std::size_t num_terms = fermi.size();
         out.terms.resize(num_terms);
-#pragma omp parallel for if(num_terms > 128)
+#pragma omp parallel for schedule(dynamic, 1) if(num_terms > 128)
         for(kk = 0; kk < num_terms; kk++)
         {
             jw_term(fermi.terms[kk], out.terms[kk]);
-            out.terms[kk].sort_term_data();
+            // elements are added high to low, so must reverse to get correct order
+            std::reverse(out.terms[kk].indices.begin(), out.terms[kk].indices.end());
+            std::reverse(out.terms[kk].values.begin(), out.terms[kk].values.end());
             set_offdiag_weight_and_phase(out.terms[kk]);
             set_extended_flag(out.terms[kk]);
             out.terms[kk].set_proj_indices();

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -13,6 +13,7 @@
  */
 #pragma once
 #include <algorithm>
+#include <boost/sort/pdqsort/pdqsort.hpp>
 #include <cmath>
 #include <complex>
 #include <cstdlib>
@@ -21,7 +22,6 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <boost/sort/pdqsort/pdqsort.hpp>
 #ifdef FQ_TBB
 #    include <oneapi/tbb/parallel_sort.h>
 #endif
@@ -29,9 +29,9 @@
 #include "constants.hpp"
 #include "fermi_term.hpp"
 #include "io.hpp"
-#include "term_utils.hpp"
 #include "oper_utils.hpp"
 #include "qubit_oper.hpp"
+#include "term_utils.hpp"
 
 // forward definitions
 void set_fermi_sorting_flags(FermionicOperator& oper, std::string kind);
@@ -294,9 +294,10 @@ typedef struct FermionicOperator
                     return term1.indices.size() < term2.indices.size();
                 });
 #else
-            boost::sort::pdqsort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
-                return term1.indices.size() < term2.indices.size();
-            });
+            boost::sort::pdqsort(
+                terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                    return term1.indices.size() < term2.indices.size();
+                });
 #endif
             set_fermi_sorting_flags(*this, "weight");
         }
@@ -317,9 +318,10 @@ typedef struct FermionicOperator
                     return term1.offdiag_structure < term2.offdiag_structure;
                 });
 #else
-            boost::sort::pdqsort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
-                return term1.offdiag_structure < term2.offdiag_structure;
-            });
+            boost::sort::pdqsort(
+                terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                    return term1.offdiag_structure < term2.offdiag_structure;
+                });
 #endif
             set_fermi_sorting_flags(*this, "structure");
         }

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -29,6 +29,7 @@
 #include "constants.hpp"
 #include "fermi_term.hpp"
 #include "io.hpp"
+#include "term_utils.hpp"
 #include "oper_utils.hpp"
 #include "qubit_oper.hpp"
 
@@ -438,7 +439,7 @@ typedef struct FermionicOperator
             std::reverse(out.terms[kk].values.begin(), out.terms[kk].values.end());
             set_offdiag_weight_and_phase(out.terms[kk]);
             set_extended_flag(out.terms[kk]);
-            out.terms[kk].set_proj_indices();
+            set_term_proj_indices(out.terms[kk]);
         }
         out.type = 2; // set type=2
         return out;

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -320,6 +320,20 @@ typedef struct FermionicOperator
         return *this;
     }
     /**
+    * Pointers to starting indices for structure sorted operator
+    * 
+    */
+    std::vector<std::size_t> offdiag_structure_ptrs()
+    {
+        std::vector<std::size_t> ptrs;
+        if(!this->structure_sorted)
+        {
+            this->offdiag_structure_sort();
+        }
+        set_offdiag_structure_ptrs(terms, ptrs);
+        return ptrs;
+    }
+    /**
     * Combine repeated terms in operator
     * 
     * @param[in] atol Tolerance for determining if a combined coefficient is zero
@@ -398,15 +412,19 @@ typedef struct FermionicOperator
     {
         FermionicOperator& fermi = *this;
         // This requires combining repeated indices
-        if(!this->combined)
+        if(!fermi.combined)
         {
             fermi = fermi.combine_repeat_indices();
+        }
+        if(!fermi.unique_terms)
+        {
+            fermi = fermi.combine_repeated_terms();
         }
         QubitOperator_t out = QubitOperator(fermi.width);
         std::size_t kk;
         std::size_t num_terms = fermi.size();
         out.terms.resize(num_terms);
-#pragma omp parallel for schedule(dynamic) if(num_terms > 128)
+#pragma omp parallel for if(num_terms > 128)
         for(kk = 0; kk < num_terms; kk++)
         {
             jw_term(fermi.terms[kk], out.terms[kk]);

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -22,20 +22,17 @@
 #include <unordered_map>
 #include <vector>
 #ifdef FQ_TBB
-#include <oneapi/tbb/parallel_sort.h>
+#    include <oneapi/tbb/parallel_sort.h>
 #endif
 
 #include "constants.hpp"
 #include "fermi_term.hpp"
 #include "io.hpp"
-#include "qubit_oper.hpp"
 #include "oper_utils.hpp"
-
+#include "qubit_oper.hpp"
 
 // forward definitions
 void set_fermi_sorting_flags(FermionicOperator& oper, std::string kind);
-
-
 
 /** @struct FermionicOperator
  * @brief Data structure for each a qubit operator, i.e. a collection of 'words'
@@ -50,7 +47,8 @@ typedef struct FermionicOperator
     unsigned int combined = 0; // have the repeated operators indices been combined?
     unsigned int unique_terms = 0; // are the terms unique? i.e. duplicates removed
     int weight_sorted{0}; // Are the operator terms weight sorted
-    int structure_sorted{0}; // Are the operator terms sorted by (non-unique) off-diagonal structure?
+    int structure_sorted{
+        0}; // Are the operator terms sorted by (non-unique) off-diagonal structure?
     std::vector<FermionicTerm_t> terms;
     FermionicOperator() {}
     /**
@@ -287,14 +285,17 @@ typedef struct FermionicOperator
     {
         if(!(this->weight_sorted))
         {
-            // sort by weight
-            #ifdef FQ_TBB
-            tbb::parallel_sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2)
-                                                  {return term1.indices.size() < term2.indices.size();});
-            #else
-            std::sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2)
-                                                  {return term1.indices.size() < term2.indices.size();});
-            #endif
+// sort by weight
+#ifdef FQ_TBB
+            tbb::parallel_sort(
+                terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                    return term1.indices.size() < term2.indices.size();
+                });
+#else
+            std::sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                return term1.indices.size() < term2.indices.size();
+            });
+#endif
             set_fermi_sorting_flags(*this, "weight");
         }
         return *this;
@@ -307,14 +308,17 @@ typedef struct FermionicOperator
     {
         if(!(this->structure_sorted))
         {
-            // sort by weight
-            #ifdef FQ_TBB
-            tbb::parallel_sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2)
-                                                  {return term1.offdiag_structure < term2.offdiag_structure;});
-            #else
-            std::sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2)
-                                                  {return term1.offdiag_structure < term2.offdiag_structure;});
-            #endif
+// sort by weight
+#ifdef FQ_TBB
+            tbb::parallel_sort(
+                terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                    return term1.offdiag_structure < term2.offdiag_structure;
+                });
+#else
+            std::sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                return term1.offdiag_structure < term2.offdiag_structure;
+            });
+#endif
             set_fermi_sorting_flags(*this, "structure");
         }
         return *this;
@@ -437,8 +441,6 @@ typedef struct FermionicOperator
         return out;
     }
 } FermionicOperator_t;
-
-
 
 /**
  * Set the FermionicOperator flags when performing sorting of various kinds

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -290,12 +290,12 @@ typedef struct FermionicOperator
 // sort by weight
 #ifdef FQ_TBB
             tbb::parallel_sort(
-                terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                terms.begin(), terms.end(), [](const FermionicTerm& term1, const FermionicTerm& term2) {
                     return term1.indices.size() < term2.indices.size();
                 });
 #else
             boost::sort::pdqsort(
-                terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                terms.begin(), terms.end(), [](const FermionicTerm& term1, const FermionicTerm& term2) {
                     return term1.indices.size() < term2.indices.size();
                 });
 #endif
@@ -314,12 +314,12 @@ typedef struct FermionicOperator
 // sort by weight
 #ifdef FQ_TBB
             tbb::parallel_sort(
-                terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                terms.begin(), terms.end(), [](const FermionicTerm& term1, const FermionicTerm& term2) {
                     return term1.offdiag_structure < term2.offdiag_structure;
                 });
 #else
             boost::sort::pdqsort(
-                terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2) {
+                terms.begin(), terms.end(), [](const FermionicTerm& term1, const FermionicTerm& term2) {
                     return term1.offdiag_structure < term2.offdiag_structure;
                 });
 #endif

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -21,6 +21,9 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#ifdef FQ_TBB
+#include <oneapi/tbb/parallel_sort.h>
+#endif
 
 #include "constants.hpp"
 #include "fermi_term.hpp"
@@ -38,6 +41,7 @@ typedef struct FermionicOperator
 {
     width_t width;
     unsigned int combined = 0; // have the repeated operators indices been combined?
+    int weight_sorted{0}; // Are the operator terms weight sorted
     std::vector<FermionicTerm_t> terms;
     FermionicOperator() {}
     /**
@@ -263,6 +267,26 @@ typedef struct FermionicOperator
         out.terms = this->terms;
         out.combined = this->combined;
         return out;
+    }
+       /**
+    * In-place sorting of terms by weight
+    * 
+    */
+    FermionicOperator& weight_sort()
+    {
+        if(!(this->weight_sorted))
+        {
+            // sort by weight
+            #ifdef FQ_TBB
+            tbb::parallel_sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2)
+                                                  {return term1.indices.size() < term2.indices.size();});
+            #else
+            std::sort(terms.begin(), terms.end(), [&](FermionicTerm term1, FermionicTerm term2)
+                                                  {return term1.indices.size() < term2.indices.size();});
+            #endif
+            this->weight_sorted = 1;
+        }
+        return *this;
     }
     /**
      * Convert operator to JSON format, optionally with XZ or ZST compression

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -362,9 +362,7 @@ typedef struct FermionicOperator
         }
         std::vector<std::size_t> ptrs;
         set_offdiag_structure_ptrs(terms, ptrs);
-        std::vector<width_t> touched;
-        touched.resize(this->size());
-        combine_terms(this->terms, out.terms, ptrs, &touched[0], atol);
+        combine_terms(this->terms, out.terms, ptrs, atol);
         this->unique_terms = 1;
         return out;
     }

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -48,6 +48,7 @@ typedef struct FermionicOperator
 {
     width_t width;
     unsigned int combined = 0; // have the repeated operators indices been combined?
+    unsigned int unique_terms = 0; // are the terms unique? i.e. duplicates removed
     int weight_sorted{0}; // Are the operator terms weight sorted
     int structure_sorted{0}; // Are the operator terms sorted by (non-unique) off-diagonal structure?
     std::vector<FermionicTerm_t> terms;
@@ -274,6 +275,8 @@ typedef struct FermionicOperator
         FermionicOperator out = FermionicOperator(this->width);
         out.terms = this->terms;
         out.combined = this->combined;
+        out.weight_sorted = this->weight_sorted;
+        out.structure_sorted = this->structure_sorted;
         return out;
     }
     /**
@@ -340,6 +343,7 @@ typedef struct FermionicOperator
         std::vector<width_t> touched;
         touched.resize(this->size());
         combine_terms(this->terms, out.terms, ptrs, &touched[0], atol);
+        this->unique_terms = 1;
         return out;
     }
     /**
@@ -396,11 +400,11 @@ typedef struct FermionicOperator
         // This requires combining repeated indices
         if(!this->combined)
         {
-            fermi = this->combine_repeat_indices();
+            fermi = fermi.combine_repeat_indices();
         }
-        QubitOperator_t out = QubitOperator(this->width);
+        QubitOperator_t out = QubitOperator(fermi.width);
         std::size_t kk;
-        std::size_t num_terms = this->size();
+        std::size_t num_terms = fermi.size();
         out.terms.resize(num_terms);
 #pragma omp parallel for schedule(dynamic) if(num_terms > 128)
         for(kk = 0; kk < num_terms; kk++)
@@ -412,7 +416,7 @@ typedef struct FermionicOperator
             out.terms[kk].set_proj_indices();
         }
         out.type = 2; // set type=2
-        return out.combine_repeated_terms();
+        return out;
     }
 } FermionicOperator_t;
 

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -289,15 +289,17 @@ typedef struct FermionicOperator
         {
 // sort by weight
 #ifdef FQ_TBB
-            tbb::parallel_sort(
-                terms.begin(), terms.end(), [](const FermionicTerm& term1, const FermionicTerm& term2) {
-                    return term1.indices.size() < term2.indices.size();
-                });
+            tbb::parallel_sort(terms.begin(),
+                               terms.end(),
+                               [](const FermionicTerm& term1, const FermionicTerm& term2) {
+                                   return term1.indices.size() < term2.indices.size();
+                               });
 #else
-            boost::sort::pdqsort(
-                terms.begin(), terms.end(), [](const FermionicTerm& term1, const FermionicTerm& term2) {
-                    return term1.indices.size() < term2.indices.size();
-                });
+            boost::sort::pdqsort(terms.begin(),
+                                 terms.end(),
+                                 [](const FermionicTerm& term1, const FermionicTerm& term2) {
+                                     return term1.indices.size() < term2.indices.size();
+                                 });
 #endif
             set_fermi_sorting_flags(*this, "weight");
         }
@@ -313,15 +315,17 @@ typedef struct FermionicOperator
         {
 // sort by weight
 #ifdef FQ_TBB
-            tbb::parallel_sort(
-                terms.begin(), terms.end(), [](const FermionicTerm& term1, const FermionicTerm& term2) {
-                    return term1.offdiag_structure < term2.offdiag_structure;
-                });
+            tbb::parallel_sort(terms.begin(),
+                               terms.end(),
+                               [](const FermionicTerm& term1, const FermionicTerm& term2) {
+                                   return term1.offdiag_structure < term2.offdiag_structure;
+                               });
 #else
-            boost::sort::pdqsort(
-                terms.begin(), terms.end(), [](const FermionicTerm& term1, const FermionicTerm& term2) {
-                    return term1.offdiag_structure < term2.offdiag_structure;
-                });
+            boost::sort::pdqsort(terms.begin(),
+                                 terms.end(),
+                                 [](const FermionicTerm& term1, const FermionicTerm& term2) {
+                                     return term1.offdiag_structure < term2.offdiag_structure;
+                                 });
 #endif
             set_fermi_sorting_flags(*this, "structure");
         }

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -430,7 +430,7 @@ typedef struct FermionicOperator
         std::size_t kk;
         std::size_t num_terms = fermi.size();
         out.terms.resize(num_terms);
-#pragma omp parallel for schedule(dynamic, 1) if(num_terms > 128)
+#pragma omp parallel for schedule(guided) if(num_terms > 1024)
         for(kk = 0; kk < num_terms; kk++)
         {
             jw_term(fermi.terms[kk], out.terms[kk]);

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -29,6 +29,8 @@
 #include "fermi_term.hpp"
 #include "io.hpp"
 #include "qubit_oper.hpp"
+#include "oper_utils.hpp"
+
 
 /** @struct FermionicOperator
  * @brief Data structure for each a qubit operator, i.e. a collection of 'words'
@@ -287,6 +289,32 @@ typedef struct FermionicOperator
             this->weight_sorted = 1;
         }
         return *this;
+    }
+    /**
+    * Combine repeated terms in operator
+    * 
+    * @param[in] atol Tolerance for determining if a combined coefficient is zero
+    * 
+    * @return Output QubitOperator with terms combined
+    * 
+    */
+    FermionicOperator combine_repeated_terms(double atol = 1e-12)
+    {
+        FermionicOperator out = FermionicOperator(this->width);
+        if(!this->size())
+        {
+            return out;
+        }
+        if(!this->weight_sorted)
+        {
+            this->weight_sort();
+        }
+        std::vector<std::size_t> weight_ptrs;
+        set_weight_ptrs(terms, weight_ptrs);
+        std::vector<width_t> touched;
+        touched.resize(this->size());
+        combine_terms(this->terms, out.terms, weight_ptrs, &touched[0], atol);
+        return out;
     }
     /**
      * Convert operator to JSON format, optionally with XZ or ZST compression

--- a/fulqrum/core/src/fermi_term.hpp
+++ b/fulqrum/core/src/fermi_term.hpp
@@ -12,8 +12,6 @@
  * that they have been altered from the originals.
  */
 #pragma once
-#include "constants.hpp"
-#include "qubit_term.hpp"
 #include <algorithm>
 #include <cmath>
 #include <complex>
@@ -23,6 +21,11 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "constants.hpp"
+#include "qubit_term.hpp"
+#include "oper_utils.hpp"
+
 
 // Fermionic components ---------------------------------------------------------------------------
 
@@ -38,6 +41,7 @@ typedef struct FermionicTerm
     std::vector<width_t> indices;
     std::complex<double> coeff;
     width_t offdiag_weight{0};
+    unsigned int offdiag_structure{0};
 
     FermionicTerm() {}
     FermionicTerm(std::complex<double> c)
@@ -48,18 +52,23 @@ typedef struct FermionicTerm
         , coeff(c)
     {
         unsigned char val;
+        width_t ind;
+        unsigned int counter = 0;
         // Iterate over string of values, mapping to new values and adding to term
         for(std::string::iterator it = vals.begin(); it != vals.end(); ++it)
         {
-            if(*it == 73)
+            counter += 1;
+            if(*it != 73)
             {
-                throw std::runtime_error("Cannot use identity operators in sparse format.");
+                val = oper_map[*it];
+                ind = inds[counter - 1];
+                values.push_back(val);
+                offdiag_weight += static_cast<width_t>(val > 2);
+                offdiag_structure += (ind + 1) * (val > 2);
             }
             else
             {
-                val = oper_map[*it];
-                values.push_back(val);
-                offdiag_weight += static_cast<width_t>(val > 2);
+                throw std::runtime_error("Cannot use identity operators in sparse format.");
             }
         }
         //check that length of values == length of indices
@@ -311,6 +320,8 @@ inline void deflate_term_indices(const FermionicTerm& term,
         }
         new_term.indices.push_back(current_index);
         new_term.values.push_back(current_value);
+        new_term.offdiag_weight += static_cast<width_t>(current_value > 2);
+        new_term.offdiag_structure += (current_index + 1) * (current_value > 2);
     }
     new_term.coeff = term.coeff;
     out_terms.push_back(new_term);

--- a/fulqrum/core/src/fermi_term.hpp
+++ b/fulqrum/core/src/fermi_term.hpp
@@ -37,6 +37,7 @@ typedef struct FermionicTerm
     std::vector<unsigned char> values;
     std::vector<width_t> indices;
     std::complex<double> coeff;
+    width_t offdiag_weight{0};
 
     FermionicTerm() {}
     FermionicTerm(std::complex<double> c)
@@ -46,6 +47,7 @@ typedef struct FermionicTerm
         : indices(inds)
         , coeff(c)
     {
+        unsigned char val;
         // Iterate over string of values, mapping to new values and adding to term
         for(std::string::iterator it = vals.begin(); it != vals.end(); ++it)
         {
@@ -55,7 +57,9 @@ typedef struct FermionicTerm
             }
             else
             {
-                values.push_back(oper_map[*it]);
+                val = oper_map[*it];
+                values.push_back(val);
+                offdiag_weight += static_cast<width_t>(val > 2);
             }
         }
         //check that length of values == length of indices

--- a/fulqrum/core/src/fermi_term.hpp
+++ b/fulqrum/core/src/fermi_term.hpp
@@ -89,6 +89,8 @@ typedef struct FermionicTerm
         FermionicTerm out = FermionicTerm(this->coeff);
         out.values = this->values;
         out.indices = this->indices;
+        out.offdiag_weight = this->offdiag_weight;
+        out.offdiag_structure = this->offdiag_structure;
         return out;
     }
     /**

--- a/fulqrum/core/src/fermi_term.hpp
+++ b/fulqrum/core/src/fermi_term.hpp
@@ -39,6 +39,8 @@ typedef struct FermionicTerm
     std::vector<unsigned char> values;
     std::vector<width_t> indices;
     std::complex<double> coeff;
+    std::vector<width_t> proj_indices;
+    std::vector<width_t> proj_bits;
     width_t offdiag_weight{0};
     unsigned int offdiag_structure{0};
 

--- a/fulqrum/core/src/fermi_term.hpp
+++ b/fulqrum/core/src/fermi_term.hpp
@@ -23,9 +23,8 @@
 #include <vector>
 
 #include "constants.hpp"
-#include "qubit_term.hpp"
 #include "oper_utils.hpp"
-
+#include "qubit_term.hpp"
 
 // Fermionic components ---------------------------------------------------------------------------
 

--- a/fulqrum/core/src/fermi_term.hpp
+++ b/fulqrum/core/src/fermi_term.hpp
@@ -43,6 +43,7 @@ typedef struct FermionicTerm
     std::vector<width_t> proj_bits;
     width_t offdiag_weight{0};
     unsigned int offdiag_structure{0};
+    unsigned int proj_structure{0};
 
     FermionicTerm() {}
     FermionicTerm(std::complex<double> c)
@@ -78,6 +79,7 @@ typedef struct FermionicTerm
             throw std::runtime_error("Size of values vector does not equal that of indices.");
         }
         insertion_sort();
+        set_term_proj_indices(*this);
     }
     // destructor
     ~FermionicTerm()
@@ -90,8 +92,11 @@ typedef struct FermionicTerm
         FermionicTerm out = FermionicTerm(this->coeff);
         out.values = this->values;
         out.indices = this->indices;
+        out.proj_indices = this->proj_indices;
+        out.proj_bits = this->proj_bits;
         out.offdiag_weight = this->offdiag_weight;
         out.offdiag_structure = this->offdiag_structure;
+        out.proj_structure = this->proj_structure;
         return out;
     }
     /**
@@ -327,5 +332,6 @@ inline void deflate_term_indices(const FermionicTerm& term,
         new_term.offdiag_structure += (current_index + 1) * (current_value > 2);
     }
     new_term.coeff = term.coeff;
+    set_term_proj_indices(new_term);
     out_terms.push_back(new_term);
 }

--- a/fulqrum/core/src/io.hpp
+++ b/fulqrum/core/src/io.hpp
@@ -303,9 +303,6 @@ inline void json_to_operator(const std::string& filename, U& oper)
             JsonTerm item = terms[kk];
             auto [a, b] = std::get<2>(item);
             OperatorTerm term = OperatorTerm(std::get<0>(item), std::get<1>(item), complex(a, b));
-            set_term_proj_indices(term);
-            set_offdiag_weight_and_phase(term);
-            set_extended_flag(term);
             oper.terms[kk] = term;
         }
         // look to see if method-type exists, should in V1.1
@@ -333,8 +330,6 @@ inline void json_to_operator(const std::string& filename, U& oper)
             JsonTerm item = terms[kk];
             auto [a, b] = std::get<2>(item);
             FermionicTerm term = FermionicTerm(std::get<0>(item), std::get<1>(item), complex(a, b));
-            term.insertion_sort();
-            set_term_proj_indices(term);
             oper.terms[kk] = term;
         }
     }

--- a/fulqrum/core/src/io.hpp
+++ b/fulqrum/core/src/io.hpp
@@ -26,6 +26,7 @@
 #include "./external/json.hpp"
 #include "base.hpp"
 #include "version.hpp"
+#include "term_utils.hpp"
 
 using json = nlohmann::json;
 typedef std::complex<double> complex;
@@ -302,7 +303,7 @@ inline void json_to_operator(const std::string& filename, U& oper)
             JsonTerm item = terms[kk];
             auto [a, b] = std::get<2>(item);
             OperatorTerm term = OperatorTerm(std::get<0>(item), std::get<1>(item), complex(a, b));
-            term.set_proj_indices();
+            set_term_proj_indices(term);
             set_offdiag_weight_and_phase(term);
             set_extended_flag(term);
             oper.terms[kk] = term;
@@ -333,6 +334,7 @@ inline void json_to_operator(const std::string& filename, U& oper)
             auto [a, b] = std::get<2>(item);
             FermionicTerm term = FermionicTerm(std::get<0>(item), std::get<1>(item), complex(a, b));
             term.insertion_sort();
+            set_term_proj_indices(term);
             oper.terms[kk] = term;
         }
     }

--- a/fulqrum/core/src/io.hpp
+++ b/fulqrum/core/src/io.hpp
@@ -25,8 +25,8 @@
 
 #include "./external/json.hpp"
 #include "base.hpp"
-#include "version.hpp"
 #include "term_utils.hpp"
+#include "version.hpp"
 
 using json = nlohmann::json;
 typedef std::complex<double> complex;

--- a/fulqrum/core/src/io.hpp
+++ b/fulqrum/core/src/io.hpp
@@ -16,8 +16,8 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <variant>
@@ -251,7 +251,7 @@ inline void json_to_operator(const std::string& filename, U& oper)
     // the file *.json file.  Ideally we would not overwrite in
     // the first place, but that is a later issue.
     bool short_filename_exists = file_exists(short_filename);
-    
+
     std::string uncompress_str;
     if(ending == "xz")
     {
@@ -276,7 +276,10 @@ inline void json_to_operator(const std::string& filename, U& oper)
     // remove temp json file if original is a compressed version
     if(ending == "xz" || ending == "zst")
     {
-        if(!short_filename_exists){std::remove(short_filename.c_str());}
+        if(!short_filename_exists)
+        {
+            std::remove(short_filename.c_str());
+        }
     }
 
     oper.width = Doc["width"];
@@ -286,7 +289,6 @@ inline void json_to_operator(const std::string& filename, U& oper)
     std::vector<std::string> version_split = split_string(Doc["format-version"], ".");
     int major_version = std::stoi(version_split[0]);
     int minor_version = std::stoi(version_split[1]);
-
 
     if constexpr(std::is_same_v<U, QubitOperator>)
     {
@@ -305,14 +307,15 @@ inline void json_to_operator(const std::string& filename, U& oper)
             set_extended_flag(term);
             oper.terms[kk] = term;
         }
-         // look to see if method-type exists, should in V1.1
-        if(major_version >=1 && minor_version >= 1)
+        // look to see if method-type exists, should in V1.1
+        if(major_version >= 1 && minor_version >= 1)
         {
             if(Doc.contains("method-type"))
             {
                 oper.type = Doc["method-type"];
             }
-            else{
+            else
+            {
                 throw std::runtime_error("JSON format 1.1+ should have a 'method-type' key");
             }
         }

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -14,9 +14,6 @@
 #pragma once
 #include <vector>
 
-#include "qubit_oper.hpp"
-#include "fermi_oper.hpp"
-
 /**
  * Compute an integer value from the off-diagonal structure of a term
  *

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -136,8 +136,8 @@ inline void combine_terms(std::vector<T>& __restrict terms,
                     continue;
                 }
                 current_term = &terms[mm];
-                // filter if offdiag weights differ
-                if(target_term.offdiag_weight != current_term->offdiag_weight)
+                // move on if number of indices does not match
+                if(target_term.indices.size() != current_term->indices.size())
                 {
                     continue;
                 }

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -14,6 +14,31 @@
 #pragma once
 #include <vector>
 
+#include "qubit_oper.hpp"
+#include "fermi_oper.hpp"
+
+/**
+ * Compute an integer value from the off-diagonal structure of a term
+ *
+ * @param term The term
+ *
+ * @return Structure value
+ */
+template <typename T>
+inline std::size_t term_offdiag_structure(const T& term)
+{
+    std::size_t kk;
+    std::size_t out = 0;
+#pragma omp simd reduction(+ : out)
+    for(kk = 0; kk < term.values.size(); ++kk)
+    {
+        out += (term.indices[kk] + 1) * (term.values[kk] > 2);
+    }
+    return out;
+}
+
+
+
 template <typename T>
 inline void set_weight_ptrs(std::vector<T>& __restrict terms,
                             std::vector<std::size_t>& vec)
@@ -35,6 +60,36 @@ inline void set_weight_ptrs(std::vector<T>& __restrict terms,
 
 
 /**
+ * Set the pointers for the off-diagonal structure
+ *
+ * @param terms Operator terms
+ * @param vec Vector to add pointers to
+ *
+ */
+template <typename T>
+inline void set_offdiag_structure_ptrs(const std::vector<T>& __restrict terms,
+                                       std::vector<std::size_t>& vec)
+{
+    vec.resize(0);
+    std::size_t kk;
+    if(terms.size())
+    {
+        std::size_t val = term_offdiag_structure(terms[0]);
+        vec.push_back(0);
+        for(kk = 1; kk < terms.size(); kk++)
+        {
+            if(term_offdiag_structure(terms[kk]) > val)
+            {
+                vec.push_back(kk);
+                val = term_offdiag_structure(terms[kk]);
+            }
+        }
+        vec.push_back(terms.size());
+    }
+}
+
+
+/**
  * Combine repeated terms that represent same
  * operators, dropping terms smaller than requested tolerance.
  *
@@ -50,26 +105,25 @@ inline void set_weight_ptrs(std::vector<T>& __restrict terms,
 template <typename T>
 inline void combine_terms(std::vector<T>& __restrict terms,
                           std::vector<T>& __restrict out_terms,
-                                width_t* touched,
-                                double atol)
+                          std::vector<std::size_t>& __restrict sort_ptrs,
+                          width_t* touched,
+                         double atol)
 {
     std::size_t kk, qq, num_terms = terms.size();
-    std::vector<std::size_t> weight_ptrs;
-    set_weight_ptrs(terms, weight_ptrs);
     std::vector<std::vector<T>> temp_terms;
-    temp_terms.resize(weight_ptrs.size() - 1);
+    temp_terms.resize(sort_ptrs.size() - 1);
     // do sort over each collection of terms with same weight
 #pragma omp parallel for schedule(dynamic) if(num_terms > 1024)
-    for(kk = 0; kk < weight_ptrs.size() - 1; kk++)
+    for(kk = 0; kk < sort_ptrs.size() - 1; kk++)
     {
         std::size_t jj, mm, pp;
         std::size_t start, stop;
         T target_term;
         T* current_term;
         int do_combine;
-        // set start and stop for terms of the same weight
-        start = weight_ptrs[kk];
-        stop = weight_ptrs[kk + 1];
+        // set start and stop for terms based on ptrs
+        start = sort_ptrs[kk];
+        stop = sort_ptrs[kk + 1];
         for(jj = start; jj < stop; jj++)
         {
             if(touched[jj]) // If touched, move onto next term
@@ -117,7 +171,7 @@ inline void combine_terms(std::vector<T>& __restrict terms,
     } //end kk-loop
 
     // at end of all, add to output terms
-    for(kk = 0; kk < weight_ptrs.size() - 1; kk++)
+    for(kk = 0; kk < sort_ptrs.size() - 1; kk++)
     {
         for(qq = 0; qq < temp_terms[kk].size(); qq++)
         {

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -91,7 +91,6 @@ inline void set_offdiag_structure_ptrs(const std::vector<T>& __restrict terms,
  *
  * @param[in] terms Terms for input operator
  * @param[in] out_terms Terms for output operator (to push_back to)
- * @param[in] touched pointer array indicating if term has been touched
  * @param[in] num_terms Number of terms in input operator
  * @param[in] atol Absolute tolerance for term truncation
  *
@@ -103,88 +102,67 @@ inline void combine_terms(std::vector<T>& __restrict terms,
                           double atol)
 {
     std::size_t kk, num_terms = terms.size();
+    const std::size_t num_blocks = sort_ptrs.size() - 1;
+    // Do a double sorting here so that we can iterate once through the terms
+    // in each block
+    auto term_data_sort = [](const T& a, const T& b) -> bool {
+        if(a.indices.size() != b.indices.size())
+            return a.indices.size() < b.indices.size();
+        if(a.indices != b.indices)
+            return a.indices < b.indices;
+        return a.values < b.values;
+    };
+    // term data equality check
+    auto term_eq = [](const T& a, const T& b) -> bool {
+        return a.indices == b.indices && a.values == b.values;
+    };
+
+    std::vector<std::vector<T>> temp_results(num_blocks);
+
 // do sort over each collection of terms with same weight
-#pragma omp parallel for if(num_terms > 4096) schedule(guided)
-    for(kk = 0; kk < sort_ptrs.size() - 1; kk++)
+#pragma omp parallel for if(num_terms > 4096)
+    for(kk = 0; kk < num_blocks; kk++)
     {
-        std::size_t jj, mm, qq;
-        std::size_t start, stop, sub_start, sub_stop;
-        T target_term;
-        T* current_term;
-        // set start and stop for terms based on ptrs
+        std::size_t start, stop;
         start = sort_ptrs[kk];
         stop = sort_ptrs[kk + 1];
-        std::vector<T> temp_terms;
+
+        std::vector<T>& temp_terms = temp_results[kk];
         temp_terms.reserve(stop - start);
-        std::vector<std::size_t> new_ptrs;
-        new_ptrs.push_back(start);
-        unsigned int val;
-        // If the number of terms in the bucket is greater than this value then
-        // do an additional sort based on the projector structure to make smaller buckets
-        // to search over
-        if(stop - start > 10000)
-        {
-            boost::sort::pdqsort(terms.begin() + start, terms.begin() + stop, [](const T& term1, const T& term2) {
-                return term1.proj_structure < term2.proj_structure;
+
+        // Sort by proj_structure, if different, otherwise sort by data
+        boost::sort::pdqsort(
+            terms.begin() + start, terms.begin() + stop, [&](const T& a, const T& b) {
+                if(a.proj_structure != b.proj_structure)
+                    return a.proj_structure < b.proj_structure;
+                return term_data_sort(a, b);
             });
-            val = terms[start].proj_structure;
-            for(jj = start + 1; jj < stop; jj++)
-            {
-                if(terms[jj].proj_structure > val)
-                {
-                    new_ptrs.push_back(jj);
-                    val = terms[jj].proj_structure;
-                }
-            }
-        }
-        new_ptrs.push_back(stop);
-        for(jj = 0; jj < new_ptrs.size() - 1; jj++)
+
+        for(std::size_t qq = start; qq < stop;)
         {
-            sub_start = new_ptrs[jj];
-            sub_stop = new_ptrs[jj + 1];
-            std::vector<bool> touched(sub_stop - sub_start, false);
-            for(qq = 0; qq < (sub_stop - sub_start); qq++)
+            T accum = terms[qq];
+            std::size_t next = qq + 1;
+            while(next < stop && term_eq(terms[next], accum))
             {
-                if(touched[qq]) // If touched, move onto next term
-                {
-                    continue;
-                }
-                touched[qq] = true;
-                T target_term = terms[qq + sub_start];
-                const std::size_t target_size = target_term.indices.size();
-                for(mm = qq + 1; mm < (sub_stop - sub_start); mm++)
-                {
-                    if(touched[mm])
-                    {
-                        continue;
-                    }
-                    current_term = &terms[mm + sub_start];
-                    // move on if number of indices does not match
-                    if(target_size != current_term->indices.size())
-                    {
-                        continue;
-                    }
-                    // look to see if indices and values match
-                    if((target_term.indices == current_term->indices) &&
-                       (target_term.values == current_term->values))
-                    {
-                        touched[mm] = true;
-                        target_term.coeff += current_term->coeff;
-                    }
-                } // end mm for-loop
-                // Add term to output if either real or imag parts are greater than atol
-                if(std::abs(target_term.coeff) > atol)
-                {
-                    temp_terms.push_back(std::move(target_term));
-                }
+                accum.coeff += terms[next].coeff;
+                ++next;
             }
-        } // end main jj loop
-#pragma omp critical
-        {
-            out_terms.insert(out_terms.end(),
-                             std::make_move_iterator(temp_terms.begin()),
-                             std::make_move_iterator(temp_terms.end()));
+            if(std::abs(accum.coeff) > atol)
+            {
+                temp_terms.push_back(std::move(accum));
+            }
+            qq = next;
         }
     } //end kk-loop
+
+    // merge all block results together into ouput operator terms
+    std::size_t total = 0;
+    for(const auto& item : temp_results)
+        total += item.size();
+    out_terms.reserve(out_terms.size() + total);
+    for(auto& item : temp_results)
+        out_terms.insert(out_terms.end(),
+                         std::make_move_iterator(item.begin()),
+                         std::make_move_iterator(item.end()));
 
 } // end combine_terms

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -12,6 +12,8 @@
  * that they have been altered from the originals.
  */
 #pragma once
+#include "constants.hpp"
+#include <boost/sort/pdqsort/pdqsort.hpp>
 #include <vector>
 
 /**

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -87,7 +87,7 @@ inline void set_offdiag_structure_ptrs(const std::vector<T>& __restrict terms,
  * Combine repeated terms that represent same
  * operators, dropping terms smaller than requested tolerance.
  *
- * Input terms must be sorted by weight before calling this routine
+ * Input terms must be sorted before calling this routine
  *
  * @param[in] terms Terms for input operator
  * @param[in] out_terms Terms for output operator (to push_back to)

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -83,8 +83,6 @@ inline void set_offdiag_structure_ptrs(const std::vector<T>& __restrict terms,
     }
 }
 
-
-
 /**
  * Combine repeated terms that represent same
  * operators, dropping terms smaller than requested tolerance.
@@ -105,8 +103,8 @@ inline void combine_terms(std::vector<T>& __restrict terms,
                           double atol)
 {
     std::size_t kk, num_terms = terms.size();
-    // do sort over each collection of terms with same weight
-    #pragma omp parallel for if(num_terms > 4096) schedule(guided)
+// do sort over each collection of terms with same weight
+#pragma omp parallel for if(num_terms > 4096) schedule(guided)
     for(kk = 0; kk < sort_ptrs.size() - 1; kk++)
     {
         std::size_t jj, mm, qq;
@@ -118,21 +116,20 @@ inline void combine_terms(std::vector<T>& __restrict terms,
         start = sort_ptrs[kk];
         stop = sort_ptrs[kk + 1];
         std::vector<T> temp_terms;
-        temp_terms.reserve(stop-start);
+        temp_terms.reserve(stop - start);
         std::vector<std::size_t> new_ptrs;
         new_ptrs.push_back(start);
         unsigned int val;
         // If the number of terms in the bucket is greater than this value then
         // do an additional sort based on the projector structure to make smaller buckets
         // to search over
-        if(stop-start > 10000)
+        if(stop - start > 10000)
         {
-            boost::sort::pdqsort(
-                    terms.begin()+start, terms.begin()+stop, [](T term1, T term2) {
-                        return term1.proj_structure < term2.proj_structure;
-                    });
+            boost::sort::pdqsort(terms.begin() + start, terms.begin() + stop, [](T term1, T term2) {
+                return term1.proj_structure < term2.proj_structure;
+            });
             val = terms[start].proj_structure;
-            for(jj = start+1; jj < stop; jj++)
+            for(jj = start + 1; jj < stop; jj++)
             {
                 if(terms[jj].proj_structure > val)
                 {
@@ -142,26 +139,26 @@ inline void combine_terms(std::vector<T>& __restrict terms,
             }
         }
         new_ptrs.push_back(stop);
-        for(jj = 0; jj < new_ptrs.size()-1; jj++)
+        for(jj = 0; jj < new_ptrs.size() - 1; jj++)
         {
             sub_start = new_ptrs[jj];
-            sub_stop = new_ptrs[jj+1];
-            std::vector<bool> touched(sub_stop-sub_start, 0);
-            for(qq=0; qq < (sub_stop-sub_start); qq++)
+            sub_stop = new_ptrs[jj + 1];
+            std::vector<bool> touched(sub_stop - sub_start, 0);
+            for(qq = 0; qq < (sub_stop - sub_start); qq++)
             {
                 if(touched[qq]) // If touched, move onto next term
                 {
                     continue;
                 }
                 touched[qq] = 1;
-                target_term = terms[qq+sub_start];
-                for(mm = qq + 1; mm < (sub_stop-sub_start); mm++)
+                target_term = terms[qq + sub_start];
+                for(mm = qq + 1; mm < (sub_stop - sub_start); mm++)
                 {
                     if(touched[mm])
                     {
                         continue;
                     }
-                    current_term = &terms[mm+sub_start];
+                    current_term = &terms[mm + sub_start];
                     // move on if number of indices does not match
                     if(target_term.indices.size() != current_term->indices.size())
                     {
@@ -170,11 +167,11 @@ inline void combine_terms(std::vector<T>& __restrict terms,
 
                     do_combine = 1;
                     // look to see if indices and values match
-                     if((target_term.indices != current_term->indices) ||
-                        (target_term.values != current_term->values))
-                        {
-                            do_combine = 0;
-                        }
+                    if((target_term.indices != current_term->indices) ||
+                       (target_term.values != current_term->values))
+                    {
+                        do_combine = 0;
+                    }
                     if(do_combine)
                     {
                         touched[mm] = 1;
@@ -188,7 +185,7 @@ inline void combine_terms(std::vector<T>& __restrict terms,
                 }
             }
         } // end main jj loop
-        #pragma omp critical
+#pragma omp critical
         {
             out_terms.insert(out_terms.end(), temp_terms.begin(), temp_terms.end());
         }

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -124,7 +124,7 @@ inline void combine_terms(std::vector<T>& __restrict terms,
         // to search over
         if(stop - start > 10000)
         {
-            boost::sort::pdqsort(terms.begin() + start, terms.begin() + stop, [](T term1, T term2) {
+            boost::sort::pdqsort(terms.begin() + start, terms.begin() + stop, [](const T& term1, const T& term2) {
                 return term1.proj_structure < term2.proj_structure;
             });
             val = terms[start].proj_structure;

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -83,6 +83,8 @@ inline void set_offdiag_structure_ptrs(const std::vector<T>& __restrict terms,
     }
 }
 
+
+
 /**
  * Combine repeated terms that represent same
  * operators, dropping terms smaller than requested tolerance.
@@ -100,77 +102,96 @@ template <typename T>
 inline void combine_terms(std::vector<T>& __restrict terms,
                           std::vector<T>& __restrict out_terms,
                           std::vector<std::size_t>& __restrict sort_ptrs,
-                          width_t* touched,
                           double atol)
 {
-    std::size_t kk, qq, num_terms = terms.size();
-    std::vector<std::vector<T>> temp_terms;
-    temp_terms.resize(sort_ptrs.size() - 1);
+    std::size_t kk, num_terms = terms.size();
     // do sort over each collection of terms with same weight
-#pragma omp parallel for schedule(dynamic) if(num_terms > 1024)
+    #pragma omp parallel for if(num_terms > 4096) schedule(guided)
     for(kk = 0; kk < sort_ptrs.size() - 1; kk++)
     {
-        std::size_t jj, mm, pp;
-        std::size_t start, stop;
+        std::size_t jj, mm, qq;
+        std::size_t start, stop, sub_start, sub_stop;
         T target_term;
         T* current_term;
         int do_combine;
         // set start and stop for terms based on ptrs
         start = sort_ptrs[kk];
         stop = sort_ptrs[kk + 1];
-        for(jj = start; jj < stop; jj++)
+        std::vector<T> temp_terms;
+        temp_terms.reserve(stop-start);
+        std::vector<std::size_t> new_ptrs;
+        new_ptrs.push_back(start);
+        unsigned int val;
+        // If the number of terms in the bucket is greater than this value then
+        // do an additional sort based on the projector structure to make smaller buckets
+        // to search over
+        if(stop-start > 10000)
         {
-            if(touched[jj]) // If touched, move onto next term
+            boost::sort::pdqsort(
+                    terms.begin()+start, terms.begin()+stop, [](T term1, T term2) {
+                        return term1.proj_structure < term2.proj_structure;
+                    });
+            val = terms[start].proj_structure;
+            for(jj = start+1; jj < stop; jj++)
             {
-                continue;
+                if(terms[jj].proj_structure > val)
+                {
+                    new_ptrs.push_back(jj);
+                    val = terms[jj].proj_structure;
+                }
             }
-            touched[jj] = 1;
-            target_term = terms[jj];
-            for(mm = jj + 1; mm < stop; mm++)
+        }
+        new_ptrs.push_back(stop);
+        for(jj = 0; jj < new_ptrs.size()-1; jj++)
+        {
+            sub_start = new_ptrs[jj];
+            sub_stop = new_ptrs[jj+1];
+            std::vector<bool> touched(sub_stop-sub_start, 0);
+            for(qq=0; qq < (sub_stop-sub_start); qq++)
             {
-                if(touched[mm])
+                if(touched[qq]) // If touched, move onto next term
                 {
                     continue;
                 }
-                current_term = &terms[mm];
-                // move on if number of indices does not match
-                if(target_term.indices.size() != current_term->indices.size())
+                touched[qq] = 1;
+                target_term = terms[qq+sub_start];
+                for(mm = qq + 1; mm < (sub_stop-sub_start); mm++)
                 {
-                    continue;
-                }
-
-                do_combine = 1;
-                // look to see if indices and values match
-                for(pp = 0; pp < target_term.indices.size(); pp++)
-                {
-                    if((target_term.indices[pp] != current_term->indices[pp]) ||
-                       (target_term.values[pp] != current_term->values[pp]))
+                    if(touched[mm])
                     {
-                        do_combine = 0;
-                        break;
+                        continue;
                     }
-                }
-                if(do_combine)
+                    current_term = &terms[mm+sub_start];
+                    // move on if number of indices does not match
+                    if(target_term.indices.size() != current_term->indices.size())
+                    {
+                        continue;
+                    }
+
+                    do_combine = 1;
+                    // look to see if indices and values match
+                     if((target_term.indices != current_term->indices) ||
+                        (target_term.values != current_term->values))
+                        {
+                            do_combine = 0;
+                        }
+                    if(do_combine)
+                    {
+                        touched[mm] = 1;
+                        target_term.coeff += current_term->coeff;
+                    }
+                } // end mm for-loop
+                // Add term to output if either real or imag parts are greater than atol
+                if(std::abs(target_term.coeff) > atol)
                 {
-                    touched[mm] = 1;
-                    target_term.coeff += current_term->coeff;
+                    temp_terms.push_back(target_term);
                 }
-            } // end mm for-loop
-            // Add term to output if either real or imag parts are greater than atol
-            if(std::abs(target_term.coeff) > atol)
-            {
-                temp_terms[kk].push_back(target_term);
             }
         } // end main jj loop
-    } //end kk-loop
-
-    // at end of all, add to output terms
-    for(kk = 0; kk < sort_ptrs.size() - 1; kk++)
-    {
-        for(qq = 0; qq < temp_terms[kk].size(); qq++)
+        #pragma omp critical
         {
-            out_terms.push_back(temp_terms[kk][qq]);
+            out_terms.insert(out_terms.end(), temp_terms.begin(), temp_terms.end());
         }
-    }
+    } //end kk-loop
 
 } // end combine_terms

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -1,0 +1,128 @@
+/**
+ * This code is part of Fulqrum.
+ *
+ * (C) Copyright IBM 2024.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+#pragma once
+#include <vector>
+
+template <typename T>
+inline void set_weight_ptrs(std::vector<T>& __restrict terms,
+                            std::vector<std::size_t>& vec)
+{
+    vec.resize(0);
+    vec.push_back(0);
+    std::size_t kk;
+    std::size_t val = terms[0].indices.size();
+    for(kk = 1; kk < terms.size(); kk++)
+    {
+        if(terms[kk].indices.size() > val)
+        {
+            vec.push_back(kk);
+            val = terms[kk].indices.size();
+        }
+    }
+    vec.push_back(terms.size());
+}
+
+
+/**
+ * Combine repeated terms that represent same
+ * operators, dropping terms smaller than requested tolerance.
+ *
+ * Input terms must be sorted by weight before calling this routine
+ *
+ * @param[in] terms Terms for input operator
+ * @param[in] out_terms Terms for output operator (to push_back to)
+ * @param[in] touched pointer array indicating if term has been touched
+ * @param[in] num_terms Number of terms in input operator
+ * @param[in] atol Absolute tolerance for term truncation
+ *
+ */
+template <typename T>
+inline void combine_terms(std::vector<T>& __restrict terms,
+                          std::vector<T>& __restrict out_terms,
+                                width_t* touched,
+                                double atol)
+{
+    std::size_t kk, qq, num_terms = terms.size();
+    std::vector<std::size_t> weight_ptrs;
+    set_weight_ptrs(terms, weight_ptrs);
+    std::vector<std::vector<T>> temp_terms;
+    temp_terms.resize(weight_ptrs.size() - 1);
+    // do sort over each collection of terms with same weight
+#pragma omp parallel for schedule(dynamic) if(num_terms > 1024)
+    for(kk = 0; kk < weight_ptrs.size() - 1; kk++)
+    {
+        std::size_t jj, mm, pp;
+        std::size_t start, stop;
+        T target_term;
+        T* current_term;
+        int do_combine;
+        // set start and stop for terms of the same weight
+        start = weight_ptrs[kk];
+        stop = weight_ptrs[kk + 1];
+        for(jj = start; jj < stop; jj++)
+        {
+            if(touched[jj]) // If touched, move onto next term
+            {
+                continue;
+            }
+            touched[jj] = 1;
+            target_term = terms[jj];
+            for(mm = jj + 1; mm < stop; mm++)
+            {
+                if(touched[mm])
+                {
+                    continue;
+                }
+                current_term = &terms[mm];
+                // filter if offdiag weights differ
+                if(target_term.offdiag_weight != current_term->offdiag_weight)
+                {
+                    continue;
+                }
+
+                do_combine = 1;
+                // look to see if indices and values match
+                for(pp = 0; pp < target_term.indices.size(); pp++)
+                {
+                    if((target_term.indices[pp] != current_term->indices[pp]) ||
+                       (target_term.values[pp] != current_term->values[pp]))
+                    {
+                        do_combine = 0;
+                        break;
+                    }
+                }
+                if(do_combine)
+                {
+                    touched[mm] = 1;
+                    target_term.coeff += current_term->coeff;
+                }
+            } // end mm for-loop
+            // Add term to output if either real or imag parts are greater than atol
+            if(std::abs(target_term.coeff) > atol)
+            {
+                temp_terms[kk].push_back(target_term);
+            }
+        } // end main jj loop
+    } //end kk-loop
+
+    // at end of all, add to output terms
+    for(kk = 0; kk < weight_ptrs.size() - 1; kk++)
+    {
+        for(qq = 0; qq < temp_terms[kk].size(); qq++)
+        {
+            out_terms.push_back(temp_terms[kk][qq]);
+        }
+    }
+
+} // end combine_terms

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -34,11 +34,8 @@ inline std::size_t term_offdiag_structure(const T& term)
     return out;
 }
 
-
-
 template <typename T>
-inline void set_weight_ptrs(std::vector<T>& __restrict terms,
-                            std::vector<std::size_t>& vec)
+inline void set_weight_ptrs(std::vector<T>& __restrict terms, std::vector<std::size_t>& vec)
 {
     vec.resize(0);
     vec.push_back(0);
@@ -54,7 +51,6 @@ inline void set_weight_ptrs(std::vector<T>& __restrict terms,
     }
     vec.push_back(terms.size());
 }
-
 
 /**
  * Set the pointers for the off-diagonal structure
@@ -85,7 +81,6 @@ inline void set_offdiag_structure_ptrs(const std::vector<T>& __restrict terms,
     }
 }
 
-
 /**
  * Combine repeated terms that represent same
  * operators, dropping terms smaller than requested tolerance.
@@ -104,7 +99,7 @@ inline void combine_terms(std::vector<T>& __restrict terms,
                           std::vector<T>& __restrict out_terms,
                           std::vector<std::size_t>& __restrict sort_ptrs,
                           width_t* touched,
-                         double atol)
+                          double atol)
 {
     std::size_t kk, qq, num_terms = terms.size();
     std::vector<std::vector<T>> temp_terms;

--- a/fulqrum/core/src/oper_utils.hpp
+++ b/fulqrum/core/src/oper_utils.hpp
@@ -111,7 +111,6 @@ inline void combine_terms(std::vector<T>& __restrict terms,
         std::size_t start, stop, sub_start, sub_stop;
         T target_term;
         T* current_term;
-        int do_combine;
         // set start and stop for terms based on ptrs
         start = sort_ptrs[kk];
         stop = sort_ptrs[kk + 1];
@@ -143,15 +142,16 @@ inline void combine_terms(std::vector<T>& __restrict terms,
         {
             sub_start = new_ptrs[jj];
             sub_stop = new_ptrs[jj + 1];
-            std::vector<bool> touched(sub_stop - sub_start, 0);
+            std::vector<bool> touched(sub_stop - sub_start, false);
             for(qq = 0; qq < (sub_stop - sub_start); qq++)
             {
                 if(touched[qq]) // If touched, move onto next term
                 {
                     continue;
                 }
-                touched[qq] = 1;
-                target_term = terms[qq + sub_start];
+                touched[qq] = true;
+                T target_term = terms[qq + sub_start];
+                const std::size_t target_size = target_term.indices.size();
                 for(mm = qq + 1; mm < (sub_stop - sub_start); mm++)
                 {
                     if(touched[mm])
@@ -160,34 +160,30 @@ inline void combine_terms(std::vector<T>& __restrict terms,
                     }
                     current_term = &terms[mm + sub_start];
                     // move on if number of indices does not match
-                    if(target_term.indices.size() != current_term->indices.size())
+                    if(target_size != current_term->indices.size())
                     {
                         continue;
                     }
-
-                    do_combine = 1;
                     // look to see if indices and values match
-                    if((target_term.indices != current_term->indices) ||
-                       (target_term.values != current_term->values))
+                    if((target_term.indices == current_term->indices) &&
+                       (target_term.values == current_term->values))
                     {
-                        do_combine = 0;
-                    }
-                    if(do_combine)
-                    {
-                        touched[mm] = 1;
+                        touched[mm] = true;
                         target_term.coeff += current_term->coeff;
                     }
                 } // end mm for-loop
                 // Add term to output if either real or imag parts are greater than atol
                 if(std::abs(target_term.coeff) > atol)
                 {
-                    temp_terms.push_back(target_term);
+                    temp_terms.push_back(std::move(target_term));
                 }
             }
         } // end main jj loop
 #pragma omp critical
         {
-            out_terms.insert(out_terms.end(), temp_terms.begin(), temp_terms.end());
+            out_terms.insert(out_terms.end(),
+                             std::make_move_iterator(temp_terms.begin()),
+                             std::make_move_iterator(temp_terms.end()));
         }
     } //end kk-loop
 

--- a/fulqrum/core/src/qubit_oper.hpp
+++ b/fulqrum/core/src/qubit_oper.hpp
@@ -31,6 +31,7 @@
 #include "constants.hpp"
 #include "io.hpp"
 #include "qubit_term.hpp"
+#include "oper_utils.hpp"
 
 struct QubitOperator;
 
@@ -52,23 +53,7 @@ inline int offweight_comp(OperatorTerm_t& term1, OperatorTerm_t& term2)
     return term1.offdiag_weight < term2.offdiag_weight;
 }
 
-inline void set_weight_ptrs(std::vector<OperatorTerm>& __restrict terms,
-                            std::vector<std::size_t>& vec)
-{
-    vec.resize(0);
-    vec.push_back(0);
-    std::size_t kk;
-    std::size_t val = terms[0].indices.size();
-    for(kk = 1; kk < terms.size(); kk++)
-    {
-        if(terms[kk].indices.size() > val)
-        {
-            vec.push_back(kk);
-            val = terms[kk].indices.size();
-        }
-    }
-    vec.push_back(terms.size());
-}
+
 
 inline void set_group_ptrs(const std::vector<OperatorTerm>& __restrict terms,
                            std::vector<std::size_t>& vec)
@@ -88,97 +73,6 @@ inline void set_group_ptrs(const std::vector<OperatorTerm>& __restrict terms,
     vec.push_back(terms.size());
 }
 
-/**
- * Combine repeated terms that represent same
- * operators, dropping terms smaller than requested tolerance.
- *
- * Input terms must be sorted by weight before calling this routine
- *
- * @param[in] terms Terms for input operator
- * @param[in] out_terms Terms for output operator (to push_back to)
- * @param[in] touched pointer array indicating if term has been touched
- * @param[in] num_terms Number of terms in input operator
- * @param[in] atol Absolute tolerance for term truncation
- *
- */
-inline void combine_qubit_terms(std::vector<OperatorTerm>& __restrict terms,
-                                std::vector<OperatorTerm>& __restrict out_terms,
-                                width_t* touched,
-                                double atol)
-{
-    std::size_t kk, qq, num_terms = terms.size();
-    std::vector<std::size_t> weight_ptrs;
-    set_weight_ptrs(terms, weight_ptrs);
-    std::vector<std::vector<OperatorTerm_t>> temp_terms;
-    temp_terms.resize(weight_ptrs.size() - 1);
-    // do sort over each collection of terms with same weight
-#pragma omp parallel for schedule(dynamic) if(num_terms > 1024)
-    for(kk = 0; kk < weight_ptrs.size() - 1; kk++)
-    {
-        std::size_t jj, mm, pp;
-        std::size_t start, stop;
-        OperatorTerm_t target_term;
-        OperatorTerm_t* current_term;
-        int do_combine;
-        // set start and stop for terms of the same weight
-        start = weight_ptrs[kk];
-        stop = weight_ptrs[kk + 1];
-        for(jj = start; jj < stop; jj++)
-        {
-            if(touched[jj]) // If touched, move onto next term
-            {
-                continue;
-            }
-            touched[jj] = 1;
-            target_term = terms[jj];
-            for(mm = jj + 1; mm < stop; mm++)
-            {
-                if(touched[mm])
-                {
-                    continue;
-                }
-                current_term = &terms[mm];
-                // filter if offdiag weights differ
-                if(target_term.offdiag_weight != current_term->offdiag_weight)
-                {
-                    continue;
-                }
-
-                do_combine = 1;
-                // look to see if indices and values match
-                for(pp = 0; pp < target_term.indices.size(); pp++)
-                {
-                    if((target_term.indices[pp] != current_term->indices[pp]) ||
-                       (target_term.values[pp] != current_term->values[pp]))
-                    {
-                        do_combine = 0;
-                        break;
-                    }
-                }
-                if(do_combine)
-                {
-                    touched[mm] = 1;
-                    target_term.coeff += current_term->coeff;
-                }
-            } // end mm for-loop
-            // Add term to output if either real or imag parts are greater than atol
-            if(std::abs(target_term.coeff) > atol)
-            {
-                temp_terms[kk].push_back(target_term);
-            }
-        } // end main jj loop
-    } //end kk-loop
-
-    // at end of all, add to output terms
-    for(kk = 0; kk < weight_ptrs.size() - 1; kk++)
-    {
-        for(qq = 0; qq < temp_terms[kk].size(); qq++)
-        {
-            out_terms.push_back(temp_terms[kk][qq]);
-        }
-    }
-
-} // end combine_qubit_terms
 
 /**
  * Compute an integer value from the off-diagonal structure of a term
@@ -1228,7 +1122,7 @@ typedef struct QubitOperator
         }
         std::vector<width_t> touched;
         touched.resize(this->size());
-        combine_qubit_terms(this->terms, out.terms, &touched[0], atol);
+        combine_terms(this->terms, out.terms, &touched[0], atol);
         out.type = this->type;
         return out;
     }

--- a/fulqrum/core/src/qubit_oper.hpp
+++ b/fulqrum/core/src/qubit_oper.hpp
@@ -728,6 +728,12 @@ typedef struct QubitOperator
         QubitOperator out = QubitOperator(this->width);
         out.terms = this->terms;
         out.type = this->type;
+        out.ladder_width = this->ladder_width;
+        out.sorted = this->sorted;
+        out.weight_sorted = this->weight_sorted;
+        out.off_weight_sorted = this->off_weight_sorted;
+        out.ladder_sorted = this->ladder_sorted;
+        out.structure_sorted = this->structure_sorted;
         return out;
     }
     /**

--- a/fulqrum/core/src/qubit_oper.hpp
+++ b/fulqrum/core/src/qubit_oper.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <algorithm>
+#include <boost/sort/pdqsort/pdqsort.hpp>
 #include <cmath>
 #include <complex>
 #include <cstdlib>
@@ -23,7 +24,6 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <boost/sort/pdqsort/pdqsort.hpp>
 #ifdef FQ_TBB
 #    include <oneapi/tbb/parallel_sort.h>
 #endif
@@ -903,9 +903,10 @@ typedef struct QubitOperator
             return term1.indices.size() < term2.indices.size();
         });
 #else
-        boost::sort::pdqsort(terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2) {
-            return term1.indices.size() < term2.indices.size();
-        });
+        boost::sort::pdqsort(
+            terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2) {
+                return term1.indices.size() < term2.indices.size();
+            });
 #endif
         set_sorting_flags(*this, "weight");
         return *this;

--- a/fulqrum/core/src/qubit_oper.hpp
+++ b/fulqrum/core/src/qubit_oper.hpp
@@ -23,8 +23,8 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-#ifdef TBB_VERSION_MAJOR
-#include <execution>
+#ifdef FQ_TBB
+#include <oneapi/tbb/parallel_sort.h>
 #endif
 
 
@@ -1062,12 +1062,13 @@ typedef struct QubitOperator
     QubitOperator& weight_sort()
     {
         // sort by weight
-        std::sort(
-            #ifdef TBB_VERSION_MAJOR
-            std::execution::par_unseq,
-            #endif
-            terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2)
-                                            {return term1.indices.size() < term2.indices.size();});
+        #ifdef FQ_TBB
+        tbb::parallel_sort(terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2)
+                                                  {return term1.indices.size() < term2.indices.size();});
+        #else
+        std::sort(terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2)
+                                                  {return term1.indices.size() < term2.indices.size();});
+        #endif
         set_sorting_flags(*this, "weight");
         return *this;
     }

--- a/fulqrum/core/src/qubit_oper.hpp
+++ b/fulqrum/core/src/qubit_oper.hpp
@@ -75,38 +75,6 @@ inline void set_group_ptrs(const std::vector<OperatorTerm>& __restrict terms,
 
 
 /**
- * Compute an integer value from the off-diagonal structure of a term
- *
- * @param term The term
- *
- * @return Structure value
- */
-inline std::size_t term_offdiag_structure(const OperatorTerm_t& term)
-{
-    std::size_t kk;
-    std::size_t out = 0;
-#pragma omp simd reduction(+ : out)
-    for(kk = 0; kk < term.values.size(); ++kk)
-    {
-        out += (term.indices[kk] + 1) * (term.values[kk] > 2);
-    }
-    return out;
-}
-
-/**
- * Comparator for off-diagonal grouping
- *
- * @param term1 The first term
- * @param term2 The second term
- *
- * @return comparator value
- */
-inline int offdiag_comp(const OperatorTerm& term1, const OperatorTerm& term2)
-{
-    return term_offdiag_structure(term1) < term_offdiag_structure(term2);
-}
-
-/**
  * Set the pointers for the off-diagonal weights
  *
  * @param terms Operator terms
@@ -131,33 +99,7 @@ inline void set_offdiag_weight_ptrs(const std::vector<OperatorTerm>& __restrict 
     vec.push_back(terms.size());
 }
 
-/**
- * Set the pointers for the off-diagonal structure
- *
- * @param terms Operator terms
- * @param vec Vector to add pointers to
- *
- */
-inline void set_offdiag_structure_ptrs(const std::vector<OperatorTerm>& __restrict terms,
-                                       std::vector<std::size_t>& vec)
-{
-    vec.resize(0);
-    std::size_t kk;
-    if(terms.size())
-    {
-        std::size_t val = term_offdiag_structure(terms[0]);
-        vec.push_back(0);
-        for(kk = 1; kk < terms.size(); kk++)
-        {
-            if(term_offdiag_structure(terms[kk]) > val)
-            {
-                vec.push_back(kk);
-                val = term_offdiag_structure(terms[kk]);
-            }
-        }
-        vec.push_back(terms.size());
-    }
-}
+
 
 /**
  * Find max. number of elements with same off-diag weight
@@ -1120,9 +1062,11 @@ typedef struct QubitOperator
         {
             this->weight_sort();
         }
+        std::vector<std::size_t> weight_ptrs;
+        set_weight_ptrs(terms, weight_ptrs);
         std::vector<width_t> touched;
         touched.resize(this->size());
-        combine_terms(this->terms, out.terms, &touched[0], atol);
+        combine_terms(this->terms, out.terms, weight_ptrs, &touched[0], atol);
         out.type = this->type;
         return out;
     }
@@ -1329,9 +1273,15 @@ inline void term_offdiag_sort(QubitOperator& oper)
 
     std::vector<std::size_t> order(n);
     std::iota(order.begin(), order.end(), 0);
+    #ifdef FQ_TBB
+    tbb::parallel_sort(order.begin(), order.end(), [&keys](std::size_t a, std::size_t b) {
+        return keys[a] < keys[b];
+    });
+    #else
     std::sort(order.begin(), order.end(), [&keys](std::size_t a, std::size_t b) {
         return keys[a] < keys[b];
     });
+    #endif
 
     std::vector<OperatorTerm_t> tmp(n);
     for(std::size_t ii = 0; ii < n; ++ii)

--- a/fulqrum/core/src/qubit_oper.hpp
+++ b/fulqrum/core/src/qubit_oper.hpp
@@ -23,6 +23,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <boost/sort/pdqsort/pdqsort.hpp>
 #ifdef FQ_TBB
 #    include <oneapi/tbb/parallel_sort.h>
 #endif
@@ -902,7 +903,7 @@ typedef struct QubitOperator
             return term1.indices.size() < term2.indices.size();
         });
 #else
-        std::sort(terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2) {
+        boost::sort::pdqsort(terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2) {
             return term1.indices.size() < term2.indices.size();
         });
 #endif
@@ -916,7 +917,7 @@ typedef struct QubitOperator
     QubitOperator& offdiag_weight_sort()
     {
         // sort by off-diagonal weight
-        std::sort(terms.begin(), terms.end(), offweight_comp);
+        boost::sort::pdqsort(terms.begin(), terms.end(), offweight_comp);
         set_sorting_flags(*this, "off_weight");
         return *this;
     }
@@ -1279,7 +1280,7 @@ inline void term_offdiag_sort(QubitOperator& oper)
         return keys[a] < keys[b];
     });
 #else
-    std::sort(order.begin(), order.end(), [&keys](std::size_t a, std::size_t b) {
+    boost::sort::pdqsort(order.begin(), order.end(), [&keys](std::size_t a, std::size_t b) {
         return keys[a] < keys[b];
     });
 #endif

--- a/fulqrum/core/src/qubit_oper.hpp
+++ b/fulqrum/core/src/qubit_oper.hpp
@@ -23,6 +23,10 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#ifdef TBB_VERSION_MAJOR
+#include <execution>
+#endif
+
 
 #include "constants.hpp"
 #include "io.hpp"
@@ -34,18 +38,6 @@ struct QubitOperator;
 void set_sorting_flags(QubitOperator& oper, std::string kind);
 inline void term_offdiag_sort(QubitOperator& oper);
 
-/**
- * Comparator for weight grouping
- *
- * @param term1 The first term
- * @param term2 The second term
- *
- * @return comparator value
- */
-inline int weight_comp(OperatorTerm& term1, OperatorTerm& term2)
-{
-    return term1.indices.size() < term2.indices.size();
-}
 
 /**
  * Comparator for off-diagonal weight grouping
@@ -1070,7 +1062,12 @@ typedef struct QubitOperator
     QubitOperator& weight_sort()
     {
         // sort by weight
-        std::sort(terms.begin(), terms.end(), weight_comp);
+        std::sort(
+            #ifdef TBB_VERSION_MAJOR
+            std::execution::par_unseq,
+            #endif
+            terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2)
+                                            {return term1.indices.size() < term2.indices.size();});
         set_sorting_flags(*this, "weight");
         return *this;
     }

--- a/fulqrum/core/src/qubit_oper.hpp
+++ b/fulqrum/core/src/qubit_oper.hpp
@@ -24,21 +24,19 @@
 #include <string>
 #include <vector>
 #ifdef FQ_TBB
-#include <oneapi/tbb/parallel_sort.h>
+#    include <oneapi/tbb/parallel_sort.h>
 #endif
-
 
 #include "constants.hpp"
 #include "io.hpp"
-#include "qubit_term.hpp"
 #include "oper_utils.hpp"
+#include "qubit_term.hpp"
 
 struct QubitOperator;
 
 // forward definitions
 void set_sorting_flags(QubitOperator& oper, std::string kind);
 inline void term_offdiag_sort(QubitOperator& oper);
-
 
 /**
  * Comparator for off-diagonal weight grouping
@@ -52,8 +50,6 @@ inline int offweight_comp(OperatorTerm_t& term1, OperatorTerm_t& term2)
 {
     return term1.offdiag_weight < term2.offdiag_weight;
 }
-
-
 
 inline void set_group_ptrs(const std::vector<OperatorTerm>& __restrict terms,
                            std::vector<std::size_t>& vec)
@@ -72,7 +68,6 @@ inline void set_group_ptrs(const std::vector<OperatorTerm>& __restrict terms,
     }
     vec.push_back(terms.size());
 }
-
 
 /**
  * Set the pointers for the off-diagonal weights
@@ -98,8 +93,6 @@ inline void set_offdiag_weight_ptrs(const std::vector<OperatorTerm>& __restrict 
     }
     vec.push_back(terms.size());
 }
-
-
 
 /**
  * Find max. number of elements with same off-diag weight
@@ -903,14 +896,16 @@ typedef struct QubitOperator
     */
     QubitOperator& weight_sort()
     {
-        // sort by weight
-        #ifdef FQ_TBB
-        tbb::parallel_sort(terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2)
-                                                  {return term1.indices.size() < term2.indices.size();});
-        #else
-        std::sort(terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2)
-                                                  {return term1.indices.size() < term2.indices.size();});
-        #endif
+// sort by weight
+#ifdef FQ_TBB
+        tbb::parallel_sort(terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2) {
+            return term1.indices.size() < term2.indices.size();
+        });
+#else
+        std::sort(terms.begin(), terms.end(), [&](OperatorTerm term1, OperatorTerm term2) {
+            return term1.indices.size() < term2.indices.size();
+        });
+#endif
         set_sorting_flags(*this, "weight");
         return *this;
     }
@@ -1279,15 +1274,15 @@ inline void term_offdiag_sort(QubitOperator& oper)
 
     std::vector<std::size_t> order(n);
     std::iota(order.begin(), order.end(), 0);
-    #ifdef FQ_TBB
+#ifdef FQ_TBB
     tbb::parallel_sort(order.begin(), order.end(), [&keys](std::size_t a, std::size_t b) {
         return keys[a] < keys[b];
     });
-    #else
+#else
     std::sort(order.begin(), order.end(), [&keys](std::size_t a, std::size_t b) {
         return keys[a] < keys[b];
     });
-    #endif
+#endif
 
     std::vector<OperatorTerm_t> tmp(n);
     for(std::size_t ii = 0; ii < n; ++ii)

--- a/fulqrum/core/src/qubit_oper.hpp
+++ b/fulqrum/core/src/qubit_oper.hpp
@@ -1067,9 +1067,7 @@ typedef struct QubitOperator
         }
         std::vector<std::size_t> weight_ptrs;
         set_weight_ptrs(terms, weight_ptrs);
-        std::vector<width_t> touched;
-        touched.resize(this->size());
-        combine_terms(this->terms, out.terms, weight_ptrs, &touched[0], atol);
+        combine_terms(this->terms, out.terms, weight_ptrs, atol);
         out.type = this->type;
         return out;
     }

--- a/fulqrum/core/src/qubit_term.hpp
+++ b/fulqrum/core/src/qubit_term.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "constants.hpp"
+#include "term_utils.hpp"
 #include "oper_utils.hpp"
 
 /** @brief Data structure for each operator term, i.e. 'word' in the operator
@@ -40,6 +41,7 @@ typedef struct OperatorTerm
     std::vector<width_t> proj_bits;
     width_t offdiag_weight{0};
     unsigned int offdiag_structure{0};
+    unsigned int proj_structure{0};
     int extended{0};
     int real_phase{1}; // 'phase' of real part (+/- 1), 0 means operator is complex-valued
     int group{-1}; // -1 means unset here
@@ -108,8 +110,11 @@ typedef struct OperatorTerm
         out.indices = this->indices;
         out.proj_indices = this->proj_indices;
         out.proj_bits = this->proj_bits;
+        out.proj_indices = this->proj_indices;
+        out.proj_bits = this->proj_bits;
         out.offdiag_weight = this->offdiag_weight;
         out.offdiag_structure = this->offdiag_structure;
+        out.proj_structure = this->proj_structure;
         return out;
     }
     /**
@@ -174,19 +179,7 @@ typedef struct OperatorTerm
      */
     OperatorTerm& set_proj_indices()
     {
-        std::size_t kk;
-        width_t val;
-        proj_indices.resize(0);
-        proj_bits.resize(0);
-        for(kk = 0; kk < values.size(); kk++)
-        {
-            val = values[kk];
-            if(val == 1 || val == 2)
-            {
-                proj_indices.push_back(indices[kk]);
-                proj_bits.push_back(val - 1);
-            }
-        }
+        set_term_proj_indices(*this);
         return *this;
     }
     std::vector<OpData> operators() const
@@ -217,24 +210,3 @@ typedef struct OperatorTerm
         return diag;
     }
 } OperatorTerm_t;
-
-/**
- * In-pace set the projector indices and bits for term in a Hamiltonian
- */
-inline OperatorTerm& set_proj_indices(OperatorTerm& term)
-{
-    std::size_t kk;
-    width_t val;
-    term.proj_indices.resize(0);
-    term.proj_bits.resize(0);
-    for(kk = 0; kk < term.values.size(); kk++)
-    {
-        val = term.values[kk];
-        if(val == 1 || val == 2)
-        {
-            term.proj_indices.push_back(term.indices[kk]);
-            term.proj_bits.push_back(val - 1);
-        }
-    }
-    return term;
-}

--- a/fulqrum/core/src/qubit_term.hpp
+++ b/fulqrum/core/src/qubit_term.hpp
@@ -12,7 +12,6 @@
  * that they have been altered from the originals.
  */
 #pragma once
-#include "constants.hpp"
 #include <algorithm>
 #include <cmath>
 #include <complex>
@@ -21,6 +20,9 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+#include "constants.hpp"
+#include "oper_utils.hpp"
 
 /** @brief Data structure for each operator term, i.e. 'word' in the operator
  *
@@ -37,6 +39,7 @@ typedef struct OperatorTerm
     std::vector<width_t> proj_indices;
     std::vector<width_t> proj_bits;
     width_t offdiag_weight{0};
+    unsigned int offdiag_structure{0};
     int extended{0};
     int real_phase{1}; // 'phase' of real part (+/- 1), 0 means operator is complex-valued
     int group{-1}; // -1 means unset here
@@ -54,6 +57,7 @@ typedef struct OperatorTerm
             throw std::runtime_error("Size of input string does not equal that of indices");
         }
         unsigned char val;
+        width_t ind;
         unsigned int counter = 0;
         // Iterate over string of values, mapping to new values and adding to term
         for(std::string::iterator it = vals.begin(); it != vals.end(); ++it)
@@ -66,9 +70,11 @@ typedef struct OperatorTerm
             else
             {
                 val = oper_map[*it];
+                ind = inds[counter - 1];
                 values.push_back(val);
-                indices.push_back(inds[counter - 1]);
+                indices.push_back(ind);
                 offdiag_weight += static_cast<width_t>(val > 2);
+                offdiag_structure += (ind+1) * (val > 2);
             }
         }
         //check that length of values == length of indices

--- a/fulqrum/core/src/qubit_term.hpp
+++ b/fulqrum/core/src/qubit_term.hpp
@@ -22,8 +22,8 @@
 #include <vector>
 
 #include "constants.hpp"
-#include "term_utils.hpp"
 #include "oper_utils.hpp"
+#include "term_utils.hpp"
 
 /** @brief Data structure for each operator term, i.e. 'word' in the operator
  *

--- a/fulqrum/core/src/qubit_term.hpp
+++ b/fulqrum/core/src/qubit_term.hpp
@@ -74,7 +74,7 @@ typedef struct OperatorTerm
                 values.push_back(val);
                 indices.push_back(ind);
                 offdiag_weight += static_cast<width_t>(val > 2);
-                offdiag_structure += (ind+1) * (val > 2);
+                offdiag_structure += (ind + 1) * (val > 2);
             }
         }
         //check that length of values == length of indices

--- a/fulqrum/core/src/qubit_term.hpp
+++ b/fulqrum/core/src/qubit_term.hpp
@@ -109,6 +109,7 @@ typedef struct OperatorTerm
         out.proj_indices = this->proj_indices;
         out.proj_bits = this->proj_bits;
         out.offdiag_weight = this->offdiag_weight;
+        out.offdiag_structure = this->offdiag_structure;
         return out;
     }
     /**

--- a/fulqrum/core/src/term_utils.hpp
+++ b/fulqrum/core/src/term_utils.hpp
@@ -1,0 +1,39 @@
+/**
+ * This code is part of Fulqrum.
+ *
+ * (C) Copyright IBM 2024.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+#pragma once
+#include <vector>
+
+/**
+ * In-pace set the projector indices and bits for term in a Hamiltonian
+ */
+template <typename T>
+inline T& set_term_proj_indices(T& term)
+{
+    std::size_t kk;
+    width_t val;
+    term.proj_indices.resize(0);
+    term.proj_bits.resize(0);
+    term.proj_structure = 0;
+    for(kk = 0; kk < term.values.size(); kk++)
+    {
+        val = term.values[kk];
+        if(val == 1 || val == 2)
+        {
+            term.proj_indices.push_back(term.indices[kk]);
+            term.proj_structure += term.indices[kk];
+            term.proj_bits.push_back(val - 1);
+        }
+    }
+    return term;
+}

--- a/fulqrum/test/test_eigen.py
+++ b/fulqrum/test/test_eigen.py
@@ -239,7 +239,7 @@ def test_eigen4():
     for kk in range(3):
         assert (
             np.linalg.norm(B.dot(evecs2[:, kk]) - evals2[kk] * evecs2[:, kk], np.inf)
-            < 1e-11  # Error a bit larger in this case
+            < 2e-11  # Error a bit larger in this case
         )
 
     # hashing only the first (`bitset.m_bits[0]`) bitset block
@@ -258,7 +258,7 @@ def test_eigen4():
     for kk in range(3):
         assert (
             np.linalg.norm(B.dot(evecs2[:, kk]) - evals2[kk] * evecs2[:, kk], np.inf)
-            < 1e-11  # Error a bit larger in this case
+            < 2e-11  # Error a bit larger in this case
         )
 
 

--- a/fulqrum/test/test_fermiop_jw.py
+++ b/fulqrum/test/test_fermiop_jw.py
@@ -353,3 +353,13 @@ def test_jwH2():
     np.allclose(ans_indices, op_mat.indices, 1e-14)
     np.allclose(ans_indptr, op_mat.indptr, 1e-14)
     np.allclose(ans_data, op_mat.data)
+
+
+def test_jw_op_ordering():
+    """Term operators are ordered low -> high in output OperatorTerms"""
+    path = Path(__file__).parent / "data/lih.json"
+    fop = FermionicOperator.from_json(path)
+    op = fop.extended_jw_transformation()
+    for kk in range(op.size):
+        ops = np.asarray([item[1] for item in op[kk].operators])
+        assert np.allclose(ops, np.sort(ops))

--- a/setup.py
+++ b/setup.py
@@ -101,12 +101,12 @@ CYTHON_SOURCE_DIRS = [
 # Add openmp flags
 OPTIONAL_FLAGS = []
 OPTIONAL_ARGS = []
+# Extra link args
+LINK_FLAGS = []
 
-if sys.platform == "win32":
-    OPTIONAL_FLAGS = ["/openmp:llvm"]
-else:
-    OPTIONAL_FLAGS = ["-fopenmp"]
-    OPTIONAL_ARGS.append("-fopenmp")
+
+OPTIONAL_FLAGS = ["-fopenmp"]
+OPTIONAL_ARGS.append("-fopenmp")
 
 if os.getenv("FQ_ARCH", False) and sys.platform != "win32":
     if sys.platform == "darwin":
@@ -117,12 +117,14 @@ if os.getenv("FQ_ARCH", False) and sys.platform != "win32":
         OPTIONAL_FLAGS.append("-march=" + os.getenv("FQ_ARCH"))
         OPTIONAL_FLAGS.append("-mtune=" + os.getenv("FQ_ARCH"))
 
+if os.getenv("FQ_TBB", False):
+    LINK_FLAGS.append('-ltbb')
+
 INCLUDE_DIRS = [np.get_include()] + [
     "fulqrum/include",
     "qiskit-addon-sqd-hpc/include",
 ]
-# Extra link args
-LINK_FLAGS = []
+
 # If on Win and not in MSYS2 (i.e. Visual studio compile)
 if sys.platform == "win32" and os.environ.get("MSYSTEM", None) is None:
     COMPILER_FLAGS = ["/O2", "/std:c++17"]

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ OPTIONAL_FLAGS = []
 OPTIONAL_ARGS = []
 # Extra link args
 LINK_FLAGS = []
+COMPILER_FLAGS = ["-O3", "-std=c++17"]
 
 
 OPTIONAL_FLAGS = ["-fopenmp"]
@@ -119,18 +120,12 @@ if os.getenv("FQ_ARCH", False) and sys.platform != "win32":
 
 if os.getenv("FQ_TBB", False):
     LINK_FLAGS.append('-ltbb')
+    COMPILER_FLAGS.append("-DFQ_TBB")
 
 INCLUDE_DIRS = [np.get_include()] + [
     "fulqrum/include",
     "qiskit-addon-sqd-hpc/include",
 ]
-
-# If on Win and not in MSYS2 (i.e. Visual studio compile)
-if sys.platform == "win32" and os.environ.get("MSYSTEM", None) is None:
-    COMPILER_FLAGS = ["/O2", "/std:c++17"]
-# Everything else
-else:
-    COMPILER_FLAGS = ["-O3", "-std=c++17"]
 
 if os.getenv("FQ_DEBUG", "0") == "1":
     COMPILER_FLAGS.append("-D_GLIBCXX_ASSERTIONS")


### PR DESCRIPTION
An attempt to speed up operator sorting and transformation.  This is done by (a) adding the option to use TBB when sorting over all the terms in an operator using the flag `FQ_TBB=1` when installing. (b) Collect repeat terms in `FermionicOperator` before the JW transform is done. (c) trying to be smarter with how the sorting routines are implemented so that they are faster.

Currently the JW transform for fe4s4 is down from 600s -> 130s on my machine.  The omp threads for JW do not all terminate at the same time, and there is a slow trail-off, with a few threads taking longer than others.  This needs to be investigated.

Combining repeated terms is also sub-optimal.  Here the operator is split into chunks based on the off-diagonal structure value, and terms within those chunks are processed in parallel looking for duplicates.  However, within each of those, there is the possibility for additional partitioning using projectors (if any).  This would yield sub-chunks that can further reduce the time for finding duplicates.  