### PR TITLE
fix projector structure setting

### DIFF
--- a/fulqrum/core/qubit_operator.pyx
+++ b/fulqrum/core/qubit_operator.pyx
@@ -848,7 +848,16 @@ cdef class QubitOperator():
         for kk in range(num_terms):
             out[kk] = passes_proj_validation(&self.oper.terms[kk], bits.bits)
         return np.asarray(out)
-
+    
+    @cython.boundscheck(False)
+    def proj_structures(self):
+        """Off-diagonal structures of each term in operator
+        """
+        cdef size_t kk
+        cdef unsigned int[::1] out = np.empty(self.oper.terms.size(), dtype=np.uint32)
+        for kk in range(self.oper.terms.size()):
+            out[kk] = self.oper.terms[kk].proj_structure
+        return np.asarray(out)
 
     @cython.boundscheck(False)
     def worst_case_offdiag_group_amplitudes(self):

--- a/fulqrum/core/src/fermi_term.hpp
+++ b/fulqrum/core/src/fermi_term.hpp
@@ -329,6 +329,7 @@ inline void deflate_term_indices(const FermionicTerm& term,
         new_term.indices.push_back(current_index);
         new_term.values.push_back(current_value);
         new_term.offdiag_weight += static_cast<width_t>(current_value > 2);
+        new_term.offdiag_structure += (current_index + 1) * (current_value > 2);
     }
     new_term.coeff = term.coeff;
     set_term_proj_indices(new_term);

--- a/fulqrum/core/src/fermi_term.hpp
+++ b/fulqrum/core/src/fermi_term.hpp
@@ -329,7 +329,6 @@ inline void deflate_term_indices(const FermionicTerm& term,
         new_term.indices.push_back(current_index);
         new_term.values.push_back(current_value);
         new_term.offdiag_weight += static_cast<width_t>(current_value > 2);
-        new_term.offdiag_structure += (current_index + 1) * (current_value > 2);
     }
     new_term.coeff = term.coeff;
     set_term_proj_indices(new_term);

--- a/fulqrum/core/src/term_utils.hpp
+++ b/fulqrum/core/src/term_utils.hpp
@@ -31,7 +31,7 @@ inline T& set_term_proj_indices(T& term)
         if(val == 1 || val == 2)
         {
             term.proj_indices.push_back(term.indices[kk]);
-            term.proj_structure += term.indices[kk];
+            term.proj_structure += (term.indices[kk] + 1);
             term.proj_bits.push_back(val - 1);
         }
     }

--- a/fulqrum/test/test_fermiop_jw.py
+++ b/fulqrum/test/test_fermiop_jw.py
@@ -363,3 +363,16 @@ def test_jw_op_ordering():
     for kk in range(op.size):
         ops = np.asarray([item[1] for item in op[kk].operators])
         assert np.allclose(ops, np.sort(ops))
+
+
+def test_jw_op_projector_structure():
+    """Term operators at output have the correct projector structure values"""
+    path = Path(__file__).parent / "data/lih.json"
+    fop = FermionicOperator.from_json(path)
+    op = fop.extended_jw_transformation()
+    pstructs = op.proj_structures()
+    for kk in range(len(op)):
+        term_pstruct = sum(
+            [(item[1] + 1) for item in op[kk].operators if item[0] in ["0", "1"]]
+        )
+        assert term_pstruct == pstructs[kk]


### PR DESCRIPTION
The routine `set_term_proj_indices` now also sets the projector structure for each term.  This was not being done correctly, i.e. missing the +1 on all the projector indices values.  This fixes that and adds a test that validates these values at the end of the JW transformation where `set_term_proj_indices` is used (amongst other places)