### PR TITLE
Move from op.num_terms to op.size()

### DIFF
--- a/docs/qubit_operators.ipynb
+++ b/docs/qubit_operators.ipynb
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "0b4ac464-687a-4ffa-a88b-aece906b0f35",
    "metadata": {},
    "outputs": [
@@ -173,7 +173,7 @@
     }
    ],
    "source": [
-    "H.num_terms"
+    "H.size()"
    ]
   },
   {
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "473ad20b-43d8-4bce-9ba1-94f62cec1f10",
    "metadata": {},
    "outputs": [
@@ -261,7 +261,7 @@
     }
    ],
    "source": [
-    "H.num_terms"
+    "H.size()"
    ]
   },
   {
@@ -365,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "ebbb4ed3-6bfd-4125-80fa-3c4f04d1e4e9",
    "metadata": {},
    "outputs": [
@@ -381,7 +381,7 @@
     }
    ],
    "source": [
-    "H.num_terms"
+    "H.size()"
    ]
   },
   {
@@ -412,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "83bd34ea-d4c6-4778-b6d3-9f3b07d2c4c4",
    "metadata": {},
    "outputs": [
@@ -428,12 +428,12 @@
     }
    ],
    "source": [
-    "diag_H.num_terms"
+    "diag_H.size()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "5191152c-7404-4580-af3a-c6edcce7c5be",
    "metadata": {},
    "outputs": [
@@ -449,7 +449,7 @@
     }
    ],
    "source": [
-    "offdiag_H.num_terms"
+    "offdiag_H.size()"
    ]
   },
   {

--- a/fulqrum/__init__.py
+++ b/fulqrum/__init__.py
@@ -12,7 +12,7 @@
 
 """Fulqrum"""
 
-__version__ = "0.2.4"
+__version__ = "0.3.0"
 
 
 from .core import (

--- a/fulqrum/core/bitset.pyx
+++ b/fulqrum/core/bitset.pyx
@@ -131,7 +131,7 @@ cdef class Bitset:
 
             FulqrumError: Size of Bitset and QubitOperator do not match
         """
-        if op.num_terms > 1:
+        if op.size() > 1:
             raise FulqrumError("Operator must contain a single-term only")
         if self.size() != op.width:
             raise FulqrumError('Bitset and Operator must have same size')

--- a/fulqrum/core/fermi_operator.pyx
+++ b/fulqrum/core/fermi_operator.pyx
@@ -249,16 +249,6 @@ cdef class FermionicOperator():
         out.oper.terms.push_back(term)
         return out
 
-    @property
-    def num_terms(self):
-        """Return the number of terms in the operator
-
-        Returns:
-            int: Number of terms in operator
-        """
-        warnings.warn("'num_terms' will be removed, use 'size()' instead")
-        return self.size()
-
     def size(self):
         """Return the number of terms in the operator
 

--- a/fulqrum/core/linear_operator.py
+++ b/fulqrum/core/linear_operator.py
@@ -47,10 +47,10 @@ class SubspaceHamiltonian(LinearOperator):
         self.group_ptrs = np.zeros(1, dtype=np.uintp)
         self.group_ladder_ptrs = np.zeros(1, dtype=np.uintp)
 
-        if self.off_H.num_terms:
+        if self.off_H.size():
             self.group_ptrs = self.off_H.group_ptrs()
         if self.off_H.type == 2:
-            if self.off_H.num_terms:
+            if self.off_H.size():
                 # Default changed from 4 to 2 as it is empirically faster.
                 # User can override using FQ_LADDER_WIDTH env flag.
                 self.off_H.group_term_sort_by_ladder_int(

--- a/fulqrum/core/qubit_operator.pyx
+++ b/fulqrum/core/qubit_operator.pyx
@@ -188,16 +188,7 @@ cdef class QubitOperator():
         else:
             raise FulqrumError("Operator must have a single-term to get coeff.  Otherwise use op.coefficients()")
 
-    @property
-    def num_terms(self):
-        """Return the number of terms in the operator
 
-        Returns:
-            int: Number of terms in operator
-        """
-        return self.oper.size()
-
-    @property
     def size(self):
         """Return the number of terms in the operator
 
@@ -250,7 +241,7 @@ cdef class QubitOperator():
         Returns:
             int : Number of groups in operator
         """
-        if self.num_terms == 0:
+        if self.size() == 0:
             return 0
         self.oper.group_sort()
         return self.oper.group_ptrs().size() - 1
@@ -358,9 +349,9 @@ cdef class QubitOperator():
         cdef size_t kk, jj
         cdef OperatorTerm_t * term
         cdef list out = []
-        if self.num_terms > 1:
+        if self.size() > 1:
             raise FulqrumError('Can only grab operators from operators with < 2 terms')
-        elif self.num_terms == 0:
+        elif self.size() == 0:
             return None
         else:
             for kk in range(self.oper.terms.size()):
@@ -872,7 +863,7 @@ cdef class QubitOperator():
             ndarray: Worse case amplitudes of groups
         """
         diag_op, _ = self.split_diagonal()
-        if diag_op.num_terms != 0:
+        if diag_op.size() != 0:
             raise FulqrumError('Operator must contain off-diagonal terms only')
         cdef size_t[::1] group_ptrs = self.group_ptrs()
         cdef size_t[::1] ladder_starts

--- a/fulqrum/test/test_convert.py
+++ b/fulqrum/test/test_convert.py
@@ -34,7 +34,7 @@ def test_openfermion_qubit_op_to_fulqrum():
 
     fulqrum_qubit_op = openfermion_qubit_op_to_fulqrum(openf_qubit_op)
 
-    for idx in range(fulqrum_qubit_op.num_terms):
+    for idx in range(fulqrum_qubit_op.size()):
         label = labels[idx].split()
         label = [(item[0], qubit_reorder_map[int(item[1:])]) for item in label]
         label = sorted(label, key=lambda x: x[1])
@@ -73,7 +73,7 @@ def test_openfermion_fermi_op_to_fulqrum():
 
     fulqrum_fermi_op = openfermion_fermi_op_to_fulqrum(openf_fermi_op)
 
-    for idx in range(fulqrum_fermi_op.num_terms):
+    for idx in range(fulqrum_fermi_op.size()):
         single_terms = []
         for elem in terms[idx].split():
             if "^" in elem:

--- a/fulqrum/test/test_eigen_H2.py
+++ b/fulqrum/test/test_eigen_H2.py
@@ -213,7 +213,7 @@ def test_full_dist_h2_eigen_csr_linearoperator_fast():
 
 def test_proj_indices_set():
     """Test that projector indices set properly after JW transform"""
-    for kk in range(OP.num_terms):
+    for kk in range(OP.size()):
         has_proj_ops = 0
         for op_idx_pair in OP[kk].operators:
             if op_idx_pair[0] in ["0", "1"]:

--- a/fulqrum/test/test_eigen_H20.py
+++ b/fulqrum/test/test_eigen_H20.py
@@ -133,7 +133,7 @@ def test_full_dist_h20_eigenenergy_csr_linearoperator_fast():
 
 def test_proj_indices_set():
     """Test that projector indices set properly after JW transform"""
-    for kk in range(NEW_OP.num_terms):
+    for kk in range(NEW_OP.size()):
         has_proj_ops = 0
         for op_idx_pair in NEW_OP[kk].operators:
             if op_idx_pair[0] in ["0", "1"]:

--- a/fulqrum/test/test_eigen_LiH.py
+++ b/fulqrum/test/test_eigen_LiH.py
@@ -289,7 +289,7 @@ def test_grnd_dist_lih_eigen_csr_fast():
 
 def test_proj_indices_set():
     """Test that projector indices set properly after JW transform"""
-    for kk in range(OP.num_terms):
+    for kk in range(OP.size()):
         has_proj_ops = 0
         for op_idx_pair in OP[kk].operators:
             if op_idx_pair[0] in ["0", "1"]:

--- a/fulqrum/test/test_fermiop_basics.py
+++ b/fulqrum/test/test_fermiop_basics.py
@@ -19,21 +19,21 @@ def test_empty_fermioperator():
     """Test empty FermionicOperator"""
     N = 5
     fo = FermionicOperator(N)
-    assert fo.num_terms == 0
+    assert fo.size() == 0
 
 
 def test_id_fermioperator1():
     """Test identity FermionicOperator"""
     N = 5
     fo = FermionicOperator(N, [()])
-    assert fo.num_terms == 1
+    assert fo.size() == 1
 
 
 def test_id_fermioperator2():
     """Test identity FermionicOperator"""
     N = 5
     fo = FermionicOperator(N, [[]])
-    assert fo.num_terms == 1
+    assert fo.size() == 1
 
 
 def test_fermioperator_coeff():

--- a/fulqrum/test/test_fermiop_collapse.py
+++ b/fulqrum/test/test_fermiop_collapse.py
@@ -217,6 +217,6 @@ def test_deflate_multi_term():
     fop += FermionicOperator(3, [("-+", [1, 1])])
     fop += FermionicOperator(3, [("+--++", [0, 0, 1, 2, 2])])  # term is zero
     fop_deflate = fop.deflate_repeated_indices()
-    assert fop_deflate.num_terms == 2  # since last term is zero
+    assert fop_deflate.size() == 2  # since last term is zero
     assert fop_deflate[0].operators == [("1", 0), ("-", 1), ("+", 2)]
     assert fop_deflate[1].operators == [("0", 1)]

--- a/fulqrum/test/test_fermiop_jw.py
+++ b/fulqrum/test/test_fermiop_jw.py
@@ -360,7 +360,7 @@ def test_jw_op_ordering():
     path = Path(__file__).parent / "data/lih.json"
     fop = FermionicOperator.from_json(path)
     op = fop.extended_jw_transformation()
-    for kk in range(op.size):
+    for kk in range(op.size()):
         ops = np.asarray([item[1] for item in op[kk].operators])
         assert np.allclose(ops, np.sort(ops))
 

--- a/fulqrum/test/test_grouping.py
+++ b/fulqrum/test/test_grouping.py
@@ -162,15 +162,15 @@ def test_square_group_pointers():
 
     h_ptrs = H.group_ptrs()
     H_diag, H_off = H.split_diagonal()
-    assert H_diag.num_terms == h_ptrs[1]
+    assert H_diag.size() == h_ptrs[1]
     hdiag_ptrs = H_diag.group_ptrs()
     assert hdiag_ptrs.shape[0] == 2
     assert hdiag_ptrs[1] == h_ptrs[1]
-    assert np.allclose(H_diag.groups(), np.zeros(H_diag.num_terms))
+    assert np.allclose(H_diag.groups(), np.zeros(H_diag.size()))
     hoff_ptrs = H_off.group_ptrs()
     # XX and YY have same off-diagonal structure so this is True here
-    assert H_off.num_terms // 2 == (hoff_ptrs.shape[0] - 1)
-    assert np.allclose(np.diff(hoff_ptrs), 2 * np.ones(H_off.num_terms // 2))
+    assert H_off.size() // 2 == (hoff_ptrs.shape[0] - 1)
+    assert np.allclose(np.diff(hoff_ptrs), 2 * np.ones(H_off.size() // 2))
 
 
 def test_square_group_pointers_h2_example():
@@ -180,8 +180,8 @@ def test_square_group_pointers_h2_example():
     op = fop.extended_jw_transformation()
     op_ptrs = op.group_ptrs()
     diag, off = op.split_diagonal()
-    assert diag.num_terms == op_ptrs[1]
-    assert off.num_terms == op_ptrs[2] - op_ptrs[1]
+    assert diag.size() == op_ptrs[1]
+    assert off.size() == op_ptrs[2] - op_ptrs[1]
     # All the elements in the off-diagonal component have the same diagonal structure
     assert np.allclose(off.group_ptrs(), np.array([0, 4]))
 

--- a/fulqrum/test/test_operator_io.py
+++ b/fulqrum/test/test_operator_io.py
@@ -26,7 +26,7 @@ def test_fermionic_json():
     FOP.to_json("lih.json", overwrite=True)
     new_fop = fq.FermionicOperator.from_json("lih.json")
     assert FOP.width == new_fop.width
-    assert FOP.num_terms == new_fop.num_terms
+    assert FOP.size() == new_fop.size()
     try:
         os.remove("lih.json")
     except FileNotFoundError:
@@ -38,7 +38,7 @@ def test_fermionic_xz():
     FOP.to_json("lih.json.xz", overwrite=True)
     new_fop = fq.FermionicOperator.from_json("lih.json.xz")
     assert FOP.width == new_fop.width
-    assert FOP.num_terms == new_fop.num_terms
+    assert FOP.size() == new_fop.size()
     try:
         os.remove("lih.json.xz")
     except FileNotFoundError:
@@ -54,7 +54,7 @@ def test_qubit_json():
     OP.to_json("lih_op.json", overwrite=True)
     new_op = fq.QubitOperator.from_json("lih_op.json")
     assert OP.width == new_op.width
-    assert OP.num_terms == new_op.num_terms
+    assert OP.size() == new_op.size()
     try:
         os.remove("lih_op.json")
     except FileNotFoundError:
@@ -66,7 +66,7 @@ def test_qubit_xz():
     OP.to_json("lih_op.json.xz", overwrite=True)
     new_op = fq.QubitOperator.from_json("lih_op.json.xz")
     assert OP.width == new_op.width
-    assert OP.num_terms == new_op.num_terms
+    assert OP.size() == new_op.size()
     try:
         os.remove("lih_op.json.xz")
     except FileNotFoundError:

--- a/fulqrum/test/test_qubitop_basics.py
+++ b/fulqrum/test/test_qubitop_basics.py
@@ -21,21 +21,21 @@ def test_empty_qubitoperator():
     """Test empty QubitOperator"""
     N = 5
     qo = QubitOperator(N)
-    assert qo.num_terms == 0
+    assert qo.size() == 0
 
 
 def test_identity():
     """Test identity QubitOperator"""
     N = 5
     qo = QubitOperator(N, [()])
-    assert qo.num_terms == 1
+    assert qo.size() == 1
 
 
 def test_identity2():
     """Test identity QubitOperator 2"""
     N = 5
     qo = QubitOperator(N, [[]])
-    assert qo.num_terms == 1
+    assert qo.size() == 1
 
 
 def test_coeff():
@@ -130,8 +130,8 @@ def test_operator_diagonal_splitting():
         op += QubitOperator(N, [(oper, 0, 1 / (N + kk))])
     diag, off_diag = op.split_diagonal()
 
-    assert diag.num_terms == 4
-    assert off_diag.num_terms == 2
+    assert diag.size() == 4
+    assert off_diag.size() == 2
 
 
 def test_operator_identity_removal():
@@ -145,7 +145,7 @@ def test_operator_identity_removal():
 
     assert abs(op.constant_energy() - 0.25757575757575757) < 1e-15
     new_op, _ = op.remove_constant_terms()
-    assert new_op.num_terms == 4
+    assert new_op.size() == 4
     assert new_op.constant_energy() == 0
 
 

--- a/fulqrum/test/test_qubitop_combine.py
+++ b/fulqrum/test/test_qubitop_combine.py
@@ -26,7 +26,7 @@ def test_combining_terms1():
     op += QubitOperator.from_label("IIIII")
     op += QubitOperator.from_label("I0YXI")
     new_op = op.combine_repeated_terms()
-    assert new_op.num_terms == 3
+    assert new_op.size() == 3
     assert np.allclose(new_op.weights(), [0, 3, 3])
     assert new_op[1].coefficients()[0] == 5.0
 
@@ -35,6 +35,6 @@ def test_combining_h2_terms():
     """Validate combining repeat qubitop terms yields same num_terms and numeric operator"""
     path = Path(__file__).parent / "data/h2.json"
     fop = FermionicOperator.from_json(path)
-    assert fop.num_terms == 36
+    assert fop.size() == 36
     op = fop.extended_jw_transformation()
-    assert op.num_terms == 14
+    assert op.size() == 14

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ruff
+ruff<0.16
 jupyter
 jupyter-sphinx
 matplotlib

--- a/tutorials/n2_full_sqd_loop.ipynb
+++ b/tutorials/n2_full_sqd_loop.ipynb
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "00d3b1a4",
    "metadata": {},
    "outputs": [
@@ -128,10 +128,10 @@
     "    one_body_integrals=hcore, two_body_integrals=eri\n",
     ")\n",
     "\n",
-    "print(f\"Num terms operator: {fermionic_op.num_terms}\")\n",
+    "print(f\"Num terms operator: {fermionic_op.size()}\")\n",
     "\n",
     "fulqrum_operator = fermionic_op.extended_jw_transformation()\n",
-    "print(f\"Num terms operator [after JW transform]: {fulqrum_operator.num_terms}\")"
+    "print(f\"Num terms operator [after JW transform]: {fulqrum_operator.size()}\")"
    ]
   },
   {


### PR DESCRIPTION
We currently have a mix of attributes and methods for determining the number of terms in an operator. This PR unifies this around `op.size()` and removes `op.num_terms`.  Additionally, it fixes the issue where `QubitOperator.size` was an attribute and not a method like `FermionicOperator.size()`.  

As this is breaking to the end user, I bumped the version to `0.3.0`