### PR TITLE
Rename operator methods

### DIFF
--- a/fulqrum/__init__.py
+++ b/fulqrum/__init__.py
@@ -12,7 +12,7 @@
 
 """Fulqrum"""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 from .core import (

--- a/fulqrum/core/fermi_operator.pyx
+++ b/fulqrum/core/fermi_operator.pyx
@@ -266,6 +266,16 @@ cdef class FermionicOperator():
         """
         return self.oper.width
 
+    def copy(self):
+        """Return a copy of the operator
+
+        Returns:
+            FermionicOperator
+        """
+        cdef FermionicOperator out = FermionicOperator(self.width)
+        out.oper = self.oper.copy()
+        return out
+
     @cython.boundscheck(False)
     def offdiag_structure_sort(self):
         """Off-diagonal structures of each term in operator

--- a/fulqrum/core/includes/base_header.pxi
+++ b/fulqrum/core/includes/base_header.pxi
@@ -101,6 +101,7 @@ cdef extern from "../src/base.hpp":
         size_t size()
         int weight_sorted
         void to_json(string, bool) except +
+        FermionicOperator_t copy()
         FermionicOperator_t from_json(string) except +
         FermionicOperator_t combine_repeat_indices() nogil
         FermionicOperator_t weight_sort() nogil

--- a/fulqrum/core/linear_operator.py
+++ b/fulqrum/core/linear_operator.py
@@ -43,7 +43,7 @@ class SubspaceHamiltonian(LinearOperator):
         self.diag_H, self.off_H = hamiltonian.split_diagonal()
         self.diag_H, self.const_energy = self.diag_H.remove_constant_terms()
         # if there are no off-diagonal terms then we pass a dummy empty array of len=1
-        self.off_H.offdiag_term_grouping()
+        self.off_H.group_sort()
         self.group_ptrs = np.zeros(1, dtype=np.uintp)
         self.group_ladder_ptrs = np.zeros(1, dtype=np.uintp)
 

--- a/fulqrum/core/qubit_operator.pyx
+++ b/fulqrum/core/qubit_operator.pyx
@@ -706,9 +706,8 @@ cdef class QubitOperator():
         return np.asarray(out)
 
 
-    def offdiag_term_grouping(self):
-        """Inplace sorting of operator terms according to off-diagonal
-        structure.
+    def group_sort(self):
+        """Inplace sorting of operator terms into groups that represent matrix-elements.
         """
         self.oper.group_sort()
 

--- a/fulqrum/test/test_fermiop_basics.py
+++ b/fulqrum/test/test_fermiop_basics.py
@@ -118,6 +118,7 @@ def test_fermioperator_from_label():
     fop2 = FermionicOperator(5, [("+1-", (0, 2, 3), -5 + 3j)])
     assert fop1.operators == fop2.operators
 
+
 def test_fermionoperator_copy():
     """Test fermi operator copy"""
     N = 6

--- a/fulqrum/test/test_fermiop_basics.py
+++ b/fulqrum/test/test_fermiop_basics.py
@@ -12,6 +12,7 @@
 # pylint: disable=no-name-in-module
 """Test basic core functionality"""
 
+import numpy as np
 from fulqrum import FermionicOperator
 
 
@@ -116,3 +117,14 @@ def test_fermioperator_from_label():
     fop1 = FermionicOperator.from_label(5, "+:0 1:2 -:3", -5 + 3j)
     fop2 = FermionicOperator(5, [("+1-", (0, 2, 3), -5 + 3j)])
     assert fop1.operators == fop2.operators
+
+def test_fermionoperator_copy():
+    """Test fermi operator copy"""
+    N = 6
+    fop1 = FermionicOperator(N, [("+", [0], 1)]) - FermionicOperator(N, [("-", [0], 2)])
+    fop2 = fop1.copy()
+    assert fop2.width == 6
+    assert fop2.size() == 2
+    assert fop2[0].operators == fop1[0].operators
+    assert fop2[1].operators == fop1[1].operators
+    assert np.allclose(fop2.coefficients(), fop1.coefficients())

--- a/fulqrum/test/test_grouping.py
+++ b/fulqrum/test/test_grouping.py
@@ -25,7 +25,7 @@ def test_grouping1():
     H = QubitOperator(2, [])
     for item in ["XY", "XI", "IY", "YY", "IZ", "II", "Z0"]:
         H += QubitOperator.from_label(item)
-    H.offdiag_term_grouping()
+    H.group_sort()
     # three diag terms, two terms of weight two, and one of each others
     ans = np.array([0, 0, 0, 1, 2, 3, 3], dtype=np.int32)
     assert np.allclose(ans, H.groups())
@@ -36,7 +36,7 @@ def test_grouping2():
     H = QubitOperator(3, [])
     for item in ["III", "ZZ1", "Z0Z", "IZI", "ZI0"]:
         H += QubitOperator.from_label(item)
-    H.offdiag_term_grouping()
+    H.group_sort()
     ans = np.zeros(5, dtype=np.int32)
     assert np.allclose(ans, H.groups())
 
@@ -46,7 +46,7 @@ def test_grouping3():
     H = QubitOperator(4, [])
     for item in ["XIIY", "+ZZ-", "Y01X", "-00+"]:
         H += QubitOperator.from_label(item)
-    H.offdiag_term_grouping()
+    H.group_sort()
     ans = np.ones(4, dtype=np.int32)
     assert np.allclose(ans, H.groups())
 
@@ -56,7 +56,7 @@ def test_grouping_split():
     H = QubitOperator(4, [])
     for item in ["XIII", "ZYII", "ZIZI", "01+Z", "IIII", "+Z00"]:
         H += QubitOperator.from_label(item)
-    H.offdiag_term_grouping()
+    H.group_sort()
     diag, offdiag = H.split_diagonal()
     diag_ans = np.zeros(len(diag))
     offdiag_ans = np.array([1, 2, 3, 3])
@@ -135,7 +135,7 @@ def test_basic_group_pointers5():
     op += fq.QubitOperator.from_label("XYYX")
     op += fq.QubitOperator.from_label("IIIX")
     assert op.num_groups == 5
-    op.offdiag_term_grouping()
+    op.group_sort()
     assert np.allclose(op.group_ptrs(), np.array([0, 2, 3, 5, 6, 7]))
 
 
@@ -217,7 +217,7 @@ def test_group_ladder_indices2():
     op += fq.QubitOperator.from_label("IYYI")
     op += fq.QubitOperator.from_label("YYYY")
     op += fq.QubitOperator.from_label("YYIY")
-    op.offdiag_term_grouping()
+    op.group_sort()
     inds_list = op.group_offdiag_indices()
     assert np.allclose(inds_list[0], np.array([0, 2], dtype=np.uint32))
     assert np.allclose(inds_list[1], np.array([3], dtype=np.uint32))
@@ -307,7 +307,7 @@ def test_group_ladder_bin_starts1():
     op += fq.QubitOperator.from_label("I---")  # int = 0
     op += fq.QubitOperator.from_label("I+++")  # int = 7
     op.set_type(2)
-    op.offdiag_term_grouping()
+    op.group_sort()
     op.group_term_sort_by_ladder_int()
 
     assert np.allclose(op.terms_by_group(2).ladder_ints(), [1, 2, 3])
@@ -346,7 +346,7 @@ def test_group_ladder_bin_starts3():
     op += fq.QubitOperator.from_label("Z0-+")  # int = 1
     op += fq.QubitOperator.from_label("ZI++")  # int = 3
     op.set_type(2)
-    op.offdiag_term_grouping()
+    op.group_sort()
     op.group_term_sort_by_ladder_int()
     assert np.allclose(op.terms_by_group(1).ladder_ints(), [0, 1, 1, 2, 2, 3, 3])
     assert np.allclose(op.terms_by_group(2).ladder_ints(), [0, 1, 1, 2, 2, 3])
@@ -429,7 +429,7 @@ def test_group_ladder_bin_starts6():
     op += fq.QubitOperator.from_label("Z00+")  # int = 1
     op += fq.QubitOperator.from_label("ZII+")  # int = 1
     op.set_type(2)
-    op.offdiag_term_grouping()
+    op.group_sort()
     op.group_term_sort_by_ladder_int()
     group_ladder_starts = op.group_ladder_bin_starts()
     ptr_size = 2**3 + 1


### PR DESCRIPTION
Makes the following name changes to operator methods:

`combine_repeated_terms` -> `combine_repeat_terms`

`offdiag_term_grouping` -> `group_sort`

Also adds a `copy()` method to `FermionicOperator`

I acidentially pushed the `combine_repeat_terms` to `main`, but it should not be too big a deal when this merges and the version gets bumped.