### PR TITLE
Faster csr for type=1 operators

### DIFF
--- a/fulqrum/__init__.py
+++ b/fulqrum/__init__.py
@@ -12,7 +12,7 @@
 
 """Fulqrum"""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 from .core import (

--- a/fulqrum/core/src/csr.hpp
+++ b/fulqrum/core/src/csr.hpp
@@ -44,38 +44,9 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
 
     const auto* bitsets = subspace.get_bitsets();
 
-    // Flatten group_offdiag_inds from a vector-of-vectors (scattered heap
-    // allocations with pointer chasing per group visit) into a single
-    // contiguous CSR-like buffer.  The indirection cost was measurable
-    // in profiles, especially for large num_groups.
-    std::vector<width_t> _flat_inds;
-    std::vector<std::size_t> _inds_offsets;
-    flatten_offdiag_inds(group_offdiag_inds, _flat_inds, _inds_offsets);
-    const width_t* __restrict flat_inds = _flat_inds.data();
-    const std::size_t* __restrict inds_offsets = _inds_offsets.data();
-    auto gview = [&](std::size_t g) -> GroupIndsView {
-        const std::size_t off = inds_offsets[g];
-        return GroupIndsView{flat_inds + off, inds_offsets[g + 1] - off};
-    };
-
-    // grp_max_inds[g] = the highest bit-flip index for group g.
-    // Used to detect lower-triangle elements without building col_vec.
-    // See get_group_max_inds() in offdiag_grouping.hpp for the rationale.
     std::vector<uint16_t> grp_max_inds(num_groups, width);
     get_group_max_inds(grp_max_inds, group_offdiag_inds, num_groups);
 
-    // Block size for the tiled outer loop.
-    std::size_t BLK = 128;
-    if(const char* _blk_env = std::getenv("FQ_BLK"))
-    {
-        long _blk = std::atol(_blk_env);
-        if(_blk > 0)
-            BLK = static_cast<std::size_t>(_blk);
-    }
-    const std::size_t rsb_w = width; // one uint8 per qubit
-    const std::size_t num_blocks = (subspace_dim + BLK - 1) / BLK;
-
-    // a vector containing the NNZ per row of the matrix
     std::vector<T> row_nnz_s(subspace_dim, 0);
     #pragma omp parallel if(subspace_dim > 4096)
     {
@@ -99,150 +70,131 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
         }
     }
 
-    // Per-thread scratch buffers, allocated once and reused for all
-    // blocks assigned to this thread (avoids per-row heap allocation).
-    std::vector<uint8_t> rsb_buf; // row_set_bits for BLK rows
-    boost::dynamic_bitset<std::size_t> col_vec(width);
-    const std::size_t num_col_blocks = col_vec.num_blocks();
-
     #pragma omp for
-    for(std::size_t blk = 0; blk < num_blocks; ++blk)
-    { 
-        const std::size_t r0 = blk * BLK;
-        const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
-        const std::size_t bn = r1 - r0;
+    for(kk = 0; kk < subspace_dim; kk++)
+    { // begin loop over all rows
+        // define variables locally for omp for loop
+        std::size_t idx;
+        std::size_t group_start, group_stop, group;
+        T row_nnz_col_idx, elem_start_col_idx;
+        const OperatorTerm_t* term;
+        const boost::dynamic_bitset<size_t>& row = bitsets[kk].first;
+        boost::dynamic_bitset<std::size_t> col_vec;
+        std::size_t* col_ptr;
+        std::size_t col_idx;
+        const std::vector<width_t>* group_inds;
+        U val;
+        T& row_nnz = row_nnz_s[kk];
+        T& elem_start = indptr[kk];
 
-        // Build the bit-vector for every row in the block.
-        // Stored contiguously as bn * rsb_w bytes so the
-        // group loop can stride over rows cheaply.
-        rsb_buf.assign(bn * rsb_w, 0);
-        for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-        {
-            const boost::dynamic_bitset<std::size_t>& row =
-                bitsets[r0 + row_in_block].first;
-            uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
-            for(std::size_t b = 0; b < row.num_blocks(); ++b)
-            {
-                std::size_t bits = row.m_bits[b];
-                while(bits != 0)
-                {
-                    int r = __builtin_ctzll(bits);
-                    dst[b * BITS_PER_BLOCK + r] = 1;
-                    bits &= bits - 1;
-                }
-            }
-        }
+        std::vector<uint8_t> row_set_bits(row.size(), 0);
+        bitset_to_bitvec(row, row_set_bits);
 
-        for(std::size_t group = 0; group < num_groups; group++)
+        for(group = 0; group < num_groups; group++)
         { // begin loop over groups
-            const GroupIndsView group_inds = gview(group);
-            const std::size_t group_start = group_ptrs[group];
-            const std::size_t group_stop = group_ptrs[group + 1];
-            if(group_start >= group_stop)
-                continue;
-
-            const uint16_t max_ind = grp_max_inds[group];
-
-            for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+            // Detects a lower or an upper
+            // triangle matrix element.
+            // See details in ``get_group_max_inds()``
+            // in fulqrum/core/src/offdiag_grouping.hpp
+            if(!row_set_bits[grp_max_inds[group]])
             {
-                const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
-                // Lower-triangle check: skip upper-triangle elements.
-                // See get_group_max_inds() in offdiag_grouping.hpp.
-                if(!row_set_bits[max_ind])
-                    continue; // continue onto new row
+                continue;
+            }
 
-                const std::size_t kk = r0 + row_in_block;
-                const boost::dynamic_bitset<std::size_t>& row = bitsets[kk].first;
-                std::memcpy(col_vec.m_bits.data(),
-                            row.m_bits.data(),
-                            num_col_blocks * sizeof(std::size_t));
-                flip_bits(col_vec, group_inds.data(), group_inds.size());
+            group_start = group_ptrs[group];
+            group_stop = group_ptrs[group + 1];
+            val = 0;
+            group_inds = &group_offdiag_inds[group];
 
-                std::size_t* col_ptr = subspace.get_ptr(col_vec);
+            if(group_start < group_stop)
+            {
+                col_vec = row;
+                flip_bits(col_vec, group_inds->data(), group_inds->size());
+
+                col_ptr = subspace.get_ptr(col_vec);
                 if(col_ptr == nullptr)
-                    continue;
-                const std::size_t col_idx = *col_ptr;
-                T row_nnz_col_idx, elem_start_col_idx;
-                T& row_nnz = row_nnz_s[kk];
-                T& elem_start = indptr[kk];
-                U val= 0;
-                for(std::size_t idx = group_start; idx < group_stop; idx++)
-                { // begin loop over terms in this group
-                    const OperatorTerm_t* term = &terms[idx];
-                    if(passes_proj_validation(term, row))
-                    {
-                        accum_element(row,
-                                    col_vec,
-                                    term->indices,
-                                    term->values,
-                                    term->coeff,
-                                    term->real_phase,
-                                    term->indices.size(),
-                                    val);
-                    }
-                } // end loop over terms in this group
-                if(std::abs(val) > ATOL)
                 {
-                    if(compute_values)
+                    break;
+                } // column is NOT in the subspace so break group
+                col_idx = *col_ptr;
+            }
+
+            for(idx = group_start; idx < group_stop; idx++)
+            { // begin loop over terms in this group
+                term = &terms[idx];
+                if(passes_proj_validation(term, row))
+                {
+                    accum_element(row,
+                                  col_vec,
+                                  term->indices,
+                                  term->values,
+                                  term->coeff,
+                                  term->real_phase,
+                                  term->indices.size(),
+                                  val);
+                }
+            } // end loop over terms in this group
+            if(std::abs(val) > ATOL)
+            {
+                if(compute_values)
+                {
+                    #pragma omp atomic write
+                    indices[elem_start + row_nnz] = col_idx;
+                    if constexpr(std::is_same_v<U, double>) // real case
                     {
                         #pragma omp atomic write
-                        indices[elem_start + row_nnz] = col_idx;
-                        if constexpr(std::is_same_v<U, double>) // real case
-                        {
-                            #pragma omp atomic write
-                            data[elem_start + row_nnz] = val;
-                        }
-                        else // imaginary case
-                        {
-                            double* __restrict p = reinterpret_cast<double*>(&data[elem_start + row_nnz]);
-                            const double* __restrict q = reinterpret_cast<const double*>(&val);
-                            #pragma omp atomic
-                            p[0] += q[0]; // real part
-                            #pragma omp atomic
-                            p[1] += q[1]; // imag part
-                        }
+                        data[elem_start + row_nnz] = val;
+                    }
+                    else // imaginary case
+                    {
+                        double* __restrict p = reinterpret_cast<double*>(&data[elem_start + row_nnz]);
+                        const double* __restrict q = reinterpret_cast<const double*>(&val);
                         #pragma omp atomic
-                        row_nnz += 1;
-                        
-                        row_nnz_col_idx = row_nnz_s[col_idx];
-                        elem_start_col_idx = indptr[col_idx];
-                        #pragma omp atomic write
-                        indices[elem_start_col_idx + row_nnz_col_idx] = kk;
+                        p[0] += q[0]; // real part
                         #pragma omp atomic
-                        row_nnz_s[col_idx] += 1;
-                        // process col_idx
-                        if constexpr(std::is_same_v<U, double>)
-                        {
-                            #pragma omp atomic write
-                            data[elem_start_col_idx + row_nnz_col_idx] = val;
-                        }
-                        else
-                        {
-                            // for complex-valued matrix, the upper triangle
-                            // element will be complex conjugate of the lower
-                            // triangle element
-                            const U update_val = std::conj(val);
-                            double* __restrict p2 = reinterpret_cast<double*>(&data[elem_start_col_idx + row_nnz_col_idx]);
-                            const double* __restrict q2 = reinterpret_cast<const double*>(&update_val);
-                            #pragma omp atomic write
-                            p2[0] = q2[0]; // real part
-                            #pragma omp atomic write
-                            p2[1] = q2[1]; // imag part
-                        }
+                        p[1] += q[1]; // imag part
+                    }
+                    #pragma omp atomic
+                    row_nnz += 1;
                     
+                    row_nnz_col_idx = row_nnz_s[col_idx];
+                    elem_start_col_idx = indptr[col_idx];
+                    #pragma omp atomic write
+                    indices[elem_start_col_idx + row_nnz_col_idx] = kk;
+                    #pragma omp atomic
+                    row_nnz_s[col_idx] += 1;
+                    // process col_idx
+                    if constexpr(std::is_same_v<U, double>)
+                    {
+                        #pragma omp atomic write
+                        data[elem_start_col_idx + row_nnz_col_idx] = val;
                     }
                     else
-                    {    
-                        #pragma omp atomic
-                        row_nnz += 1;
-
-                        #pragma omp atomic
-                        row_nnz_s[col_idx] += 1;
+                    {
+                        // for complex-valued matrix, the upper triangle
+                        // element will be complex conjugate of the lower
+                        // triangle element
+                        const U update_val = std::conj(val);
+                        double* __restrict p2 = reinterpret_cast<double*>(&data[elem_start_col_idx + row_nnz_col_idx]);
+                        const double* __restrict q2 = reinterpret_cast<const double*>(&update_val);
+                        #pragma omp atomic write
+                        p2[0] = q2[0]; // real part
+                        #pragma omp atomic write
+                        p2[1] = q2[1]; // imag part
                     }
+                 
                 }
-            } // end loop over row block
+                if(!compute_values)
+                {    
+                    #pragma omp atomic
+                    row_nnz += 1;
+
+                    #pragma omp atomic
+                    row_nnz_s[col_idx] += 1;
+                }
+            }
         } // end loop over groups
-    } // end loop over all row blocks
+    } // end loop over all rows
     } // end omp parallel region
 
     if(!compute_values) // Done with all rows so accumulate for correct indptr structure

--- a/fulqrum/core/src/csr.hpp
+++ b/fulqrum/core/src/csr.hpp
@@ -152,20 +152,31 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
                     // simultaneous writing into a same vector.
                     #pragma omp atomic write
                     indices[elem_start + row_nnz] = col_idx;
-                    { // process kk (row index)
-                        std::lock_guard<std::mutex> lock_kk(mutex1[kk]);
+                    if constexpr(std::is_same_v<U, double>)
+                    {
+                        #pragma omp atomic write
                         data[elem_start + row_nnz] = val;
+                    }
+                    else
+                    {
+                        double* __restrict p = reinterpret_cast<double*>(&data[elem_start + row_nnz]);
+                        const double* __restrict q = reinterpret_cast<const double*>(&val);
+                        #pragma omp atomic
+                        p[0] += q[0]; // real part
+                        #pragma omp atomic
+                        p[1] += q[1]; // imag part
                     }
                     #pragma omp atomic
                     row_nnz += 1;
                     
                     row_nnz_col_idx = row_nnz_s[col_idx];
                     elem_start_col_idx = indptr[col_idx];
+                    #pragma omp atomic write
+                    indices[elem_start_col_idx + row_nnz_col_idx] = kk;
+                    #pragma omp atomic
+                    row_nnz_s[col_idx] += 1;
                     { // process col_idx
                         std::lock_guard<std::mutex> lock_col_idx(mutex1[col_idx]);
-                        indices[elem_start_col_idx + row_nnz_col_idx] = kk;
-                        row_nnz_s[col_idx] += 1;
-
                         if constexpr(std::is_same_v<U, double>)
                         {
                             data[elem_start_col_idx + row_nnz_col_idx] = val;

--- a/fulqrum/core/src/csr.hpp
+++ b/fulqrum/core/src/csr.hpp
@@ -44,9 +44,38 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
 
     const auto* bitsets = subspace.get_bitsets();
 
+    // Flatten group_offdiag_inds from a vector-of-vectors (scattered heap
+    // allocations with pointer chasing per group visit) into a single
+    // contiguous CSR-like buffer.  The indirection cost was measurable
+    // in profiles, especially for large num_groups.
+    std::vector<width_t> _flat_inds;
+    std::vector<std::size_t> _inds_offsets;
+    flatten_offdiag_inds(group_offdiag_inds, _flat_inds, _inds_offsets);
+    const width_t* __restrict flat_inds = _flat_inds.data();
+    const std::size_t* __restrict inds_offsets = _inds_offsets.data();
+    auto gview = [&](std::size_t g) -> GroupIndsView {
+        const std::size_t off = inds_offsets[g];
+        return GroupIndsView{flat_inds + off, inds_offsets[g + 1] - off};
+    };
+
+    // grp_max_inds[g] = the highest bit-flip index for group g.
+    // Used to detect lower-triangle elements without building col_vec.
+    // See get_group_max_inds() in offdiag_grouping.hpp for the rationale.
     std::vector<uint16_t> grp_max_inds(num_groups, width);
     get_group_max_inds(grp_max_inds, group_offdiag_inds, num_groups);
 
+    // Block size for the tiled outer loop.
+    std::size_t BLK = 128;
+    if(const char* _blk_env = std::getenv("FQ_BLK"))
+    {
+        long _blk = std::atol(_blk_env);
+        if(_blk > 0)
+            BLK = static_cast<std::size_t>(_blk);
+    }
+    const std::size_t rsb_w = width; // one uint8 per qubit
+    const std::size_t num_blocks = (subspace_dim + BLK - 1) / BLK;
+
+    // a vector containing the NNZ per row of the matrix
     std::vector<T> row_nnz_s(subspace_dim, 0);
     #pragma omp parallel if(subspace_dim > 4096)
     {
@@ -70,131 +99,150 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
         }
     }
 
+    // Per-thread scratch buffers, allocated once and reused for all
+    // blocks assigned to this thread (avoids per-row heap allocation).
+    std::vector<uint8_t> rsb_buf; // row_set_bits for BLK rows
+    boost::dynamic_bitset<std::size_t> col_vec(width);
+    const std::size_t num_col_blocks = col_vec.num_blocks();
+
     #pragma omp for
-    for(kk = 0; kk < subspace_dim; kk++)
-    { // begin loop over all rows
-        // define variables locally for omp for loop
-        std::size_t idx;
-        std::size_t group_start, group_stop, group;
-        T row_nnz_col_idx, elem_start_col_idx;
-        const OperatorTerm_t* term;
-        const boost::dynamic_bitset<size_t>& row = bitsets[kk].first;
-        boost::dynamic_bitset<std::size_t> col_vec;
-        std::size_t* col_ptr;
-        std::size_t col_idx;
-        const std::vector<width_t>* group_inds;
-        U val;
-        T& row_nnz = row_nnz_s[kk];
-        T& elem_start = indptr[kk];
+    for(std::size_t blk = 0; blk < num_blocks; ++blk)
+    { 
+        const std::size_t r0 = blk * BLK;
+        const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
+        const std::size_t bn = r1 - r0;
 
-        std::vector<uint8_t> row_set_bits(row.size(), 0);
-        bitset_to_bitvec(row, row_set_bits);
-
-        for(group = 0; group < num_groups; group++)
-        { // begin loop over groups
-            // Detects a lower or an upper
-            // triangle matrix element.
-            // See details in ``get_group_max_inds()``
-            // in fulqrum/core/src/offdiag_grouping.hpp
-            if(!row_set_bits[grp_max_inds[group]])
+        // Build the bit-vector for every row in the block.
+        // Stored contiguously as bn * rsb_w bytes so the
+        // group loop can stride over rows cheaply.
+        rsb_buf.assign(bn * rsb_w, 0);
+        for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+        {
+            const boost::dynamic_bitset<std::size_t>& row =
+                bitsets[r0 + row_in_block].first;
+            uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
+            for(std::size_t b = 0; b < row.num_blocks(); ++b)
             {
-                continue;
-            }
-
-            group_start = group_ptrs[group];
-            group_stop = group_ptrs[group + 1];
-            val = 0;
-            group_inds = &group_offdiag_inds[group];
-
-            if(group_start < group_stop)
-            {
-                col_vec = row;
-                flip_bits(col_vec, group_inds->data(), group_inds->size());
-
-                col_ptr = subspace.get_ptr(col_vec);
-                if(col_ptr == nullptr)
+                std::size_t bits = row.m_bits[b];
+                while(bits != 0)
                 {
-                    break;
-                } // column is NOT in the subspace so break group
-                col_idx = *col_ptr;
-            }
-
-            for(idx = group_start; idx < group_stop; idx++)
-            { // begin loop over terms in this group
-                term = &terms[idx];
-                if(passes_proj_validation(term, row))
-                {
-                    accum_element(row,
-                                  col_vec,
-                                  term->indices,
-                                  term->values,
-                                  term->coeff,
-                                  term->real_phase,
-                                  term->indices.size(),
-                                  val);
+                    int r = __builtin_ctzll(bits);
+                    dst[b * BITS_PER_BLOCK + r] = 1;
+                    bits &= bits - 1;
                 }
-            } // end loop over terms in this group
-            if(std::abs(val) > ATOL)
+            }
+        }
+
+        for(std::size_t group = 0; group < num_groups; group++)
+        { // begin loop over groups
+            const GroupIndsView group_inds = gview(group);
+            const std::size_t group_start = group_ptrs[group];
+            const std::size_t group_stop = group_ptrs[group + 1];
+            if(group_start >= group_stop)
+                continue;
+
+            const uint16_t max_ind = grp_max_inds[group];
+
+            for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
             {
-                if(compute_values)
+                const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                // Lower-triangle check: skip upper-triangle elements.
+                // See get_group_max_inds() in offdiag_grouping.hpp.
+                if(!row_set_bits[max_ind])
+                    continue; // continue onto new row
+
+                const std::size_t kk = r0 + row_in_block;
+                const boost::dynamic_bitset<std::size_t>& row = bitsets[kk].first;
+                std::memcpy(col_vec.m_bits.data(),
+                            row.m_bits.data(),
+                            num_col_blocks * sizeof(std::size_t));
+                flip_bits(col_vec, group_inds.data(), group_inds.size());
+
+                std::size_t* col_ptr = subspace.get_ptr(col_vec);
+                if(col_ptr == nullptr)
+                    continue;
+                const std::size_t col_idx = *col_ptr;
+                T row_nnz_col_idx, elem_start_col_idx;
+                T& row_nnz = row_nnz_s[kk];
+                T& elem_start = indptr[kk];
+                U val= 0;
+                for(std::size_t idx = group_start; idx < group_stop; idx++)
+                { // begin loop over terms in this group
+                    const OperatorTerm_t* term = &terms[idx];
+                    if(passes_proj_validation(term, row))
+                    {
+                        accum_element(row,
+                                    col_vec,
+                                    term->indices,
+                                    term->values,
+                                    term->coeff,
+                                    term->real_phase,
+                                    term->indices.size(),
+                                    val);
+                    }
+                } // end loop over terms in this group
+                if(std::abs(val) > ATOL)
                 {
-                    #pragma omp atomic write
-                    indices[elem_start + row_nnz] = col_idx;
-                    if constexpr(std::is_same_v<U, double>) // real case
+                    if(compute_values)
                     {
                         #pragma omp atomic write
-                        data[elem_start + row_nnz] = val;
-                    }
-                    else // imaginary case
-                    {
-                        double* __restrict p = reinterpret_cast<double*>(&data[elem_start + row_nnz]);
-                        const double* __restrict q = reinterpret_cast<const double*>(&val);
+                        indices[elem_start + row_nnz] = col_idx;
+                        if constexpr(std::is_same_v<U, double>) // real case
+                        {
+                            #pragma omp atomic write
+                            data[elem_start + row_nnz] = val;
+                        }
+                        else // imaginary case
+                        {
+                            double* __restrict p = reinterpret_cast<double*>(&data[elem_start + row_nnz]);
+                            const double* __restrict q = reinterpret_cast<const double*>(&val);
+                            #pragma omp atomic
+                            p[0] += q[0]; // real part
+                            #pragma omp atomic
+                            p[1] += q[1]; // imag part
+                        }
                         #pragma omp atomic
-                        p[0] += q[0]; // real part
+                        row_nnz += 1;
+                        
+                        row_nnz_col_idx = row_nnz_s[col_idx];
+                        elem_start_col_idx = indptr[col_idx];
+                        #pragma omp atomic write
+                        indices[elem_start_col_idx + row_nnz_col_idx] = kk;
                         #pragma omp atomic
-                        p[1] += q[1]; // imag part
-                    }
-                    #pragma omp atomic
-                    row_nnz += 1;
+                        row_nnz_s[col_idx] += 1;
+                        // process col_idx
+                        if constexpr(std::is_same_v<U, double>)
+                        {
+                            #pragma omp atomic write
+                            data[elem_start_col_idx + row_nnz_col_idx] = val;
+                        }
+                        else
+                        {
+                            // for complex-valued matrix, the upper triangle
+                            // element will be complex conjugate of the lower
+                            // triangle element
+                            const U update_val = std::conj(val);
+                            double* __restrict p2 = reinterpret_cast<double*>(&data[elem_start_col_idx + row_nnz_col_idx]);
+                            const double* __restrict q2 = reinterpret_cast<const double*>(&update_val);
+                            #pragma omp atomic write
+                            p2[0] = q2[0]; // real part
+                            #pragma omp atomic write
+                            p2[1] = q2[1]; // imag part
+                        }
                     
-                    row_nnz_col_idx = row_nnz_s[col_idx];
-                    elem_start_col_idx = indptr[col_idx];
-                    #pragma omp atomic write
-                    indices[elem_start_col_idx + row_nnz_col_idx] = kk;
-                    #pragma omp atomic
-                    row_nnz_s[col_idx] += 1;
-                    // process col_idx
-                    if constexpr(std::is_same_v<U, double>)
-                    {
-                        #pragma omp atomic write
-                        data[elem_start_col_idx + row_nnz_col_idx] = val;
                     }
                     else
-                    {
-                        // for complex-valued matrix, the upper triangle
-                        // element will be complex conjugate of the lower
-                        // triangle element
-                        const U update_val = std::conj(val);
-                        double* __restrict p2 = reinterpret_cast<double*>(&data[elem_start_col_idx + row_nnz_col_idx]);
-                        const double* __restrict q2 = reinterpret_cast<const double*>(&update_val);
-                        #pragma omp atomic write
-                        p2[0] = q2[0]; // real part
-                        #pragma omp atomic write
-                        p2[1] = q2[1]; // imag part
-                    }
-                 
-                }
-                if(!compute_values)
-                {    
-                    #pragma omp atomic
-                    row_nnz += 1;
+                    {    
+                        #pragma omp atomic
+                        row_nnz += 1;
 
-                    #pragma omp atomic
-                    row_nnz_s[col_idx] += 1;
+                        #pragma omp atomic
+                        row_nnz_s[col_idx] += 1;
+                    }
                 }
-            }
+            } // end loop over row block
         } // end loop over groups
-    } // end loop over all rows
+    } // end loop over all row blocks
     } // end omp parallel region
 
     if(!compute_values) // Done with all rows so accumulate for correct indptr structure

--- a/fulqrum/core/src/csr.hpp
+++ b/fulqrum/core/src/csr.hpp
@@ -14,7 +14,6 @@
 #pragma once
 #include <complex>
 #include <cstdlib>
-#include <mutex>
 #include <vector>
 
 #include "base.hpp"
@@ -44,9 +43,6 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
     T temp, _sum;
 
     const auto* bitsets = subspace.get_bitsets();
-
-    std::vector<std::mutex> mutex1(subspace_dim);
-    std::vector<std::mutex> mutex2(subspace_dim);
 
     std::vector<uint16_t> grp_max_inds(num_groups, width);
     get_group_max_inds(grp_max_inds, group_offdiag_inds, num_groups);
@@ -140,24 +136,14 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
             {
                 if(compute_values)
                 {
-                    // Mutex locks to avoid write contention
-                    // inside OMP parallel for loop. After
-                    // detecting an lower triangle elements, we
-                    // also populate corresponding upper
-                    // triangle position. It may lead to
-                    // multiple parallel threads writing into
-                    // the same inner vector at the same time.
-                    // These scoped (inside each curly braces
-                    // {}) Mutex-based locks prevents
-                    // simultaneous writing into a same vector.
                     #pragma omp atomic write
                     indices[elem_start + row_nnz] = col_idx;
-                    if constexpr(std::is_same_v<U, double>)
+                    if constexpr(std::is_same_v<U, double>) // real case
                     {
                         #pragma omp atomic write
                         data[elem_start + row_nnz] = val;
                     }
-                    else
+                    else // imaginary case
                     {
                         double* __restrict p = reinterpret_cast<double*>(&data[elem_start + row_nnz]);
                         const double* __restrict q = reinterpret_cast<const double*>(&val);
@@ -175,20 +161,26 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
                     indices[elem_start_col_idx + row_nnz_col_idx] = kk;
                     #pragma omp atomic
                     row_nnz_s[col_idx] += 1;
-                    { // process col_idx
-                        std::lock_guard<std::mutex> lock_col_idx(mutex1[col_idx]);
-                        if constexpr(std::is_same_v<U, double>)
-                        {
-                            data[elem_start_col_idx + row_nnz_col_idx] = val;
-                        }
-                        else
-                        {
-                            // for complex-valued matrix, the upper triangle
-                            // element will be complex conjugate of the lower
-                            // triangle element
-                            data[elem_start_col_idx + row_nnz_col_idx] = std::conj(val);
-                        }
+                    // process col_idx
+                    if constexpr(std::is_same_v<U, double>)
+                    {
+                        #pragma omp atomic write
+                        data[elem_start_col_idx + row_nnz_col_idx] = val;
                     }
+                    else
+                    {
+                        // for complex-valued matrix, the upper triangle
+                        // element will be complex conjugate of the lower
+                        // triangle element
+                        const U update_val = std::conj(val);
+                        double* __restrict p2 = reinterpret_cast<double*>(&data[elem_start_col_idx + row_nnz_col_idx]);
+                        const double* __restrict q2 = reinterpret_cast<const double*>(&update_val);
+                        #pragma omp atomic write
+                        p2[0] = q2[0]; // real part
+                        #pragma omp atomic write
+                        p2[1] = q2[1]; // imag part
+                    }
+                 
                 }
                 if(!compute_values)
                 {    

--- a/fulqrum/core/src/csr.hpp
+++ b/fulqrum/core/src/csr.hpp
@@ -150,18 +150,19 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
                     // These scoped (inside each curly braces
                     // {}) Mutex-based locks prevents
                     // simultaneous writing into a same vector.
+                    #pragma omp atomic write
+                    indices[elem_start + row_nnz] = col_idx;
                     { // process kk (row index)
                         std::lock_guard<std::mutex> lock_kk(mutex1[kk]);
-
-                        indices[elem_start + row_nnz] = col_idx;
                         data[elem_start + row_nnz] = val;
-                        row_nnz += 1;
                     }
-
+                    #pragma omp atomic
+                    row_nnz += 1;
+                    
+                    row_nnz_col_idx = row_nnz_s[col_idx];
+                    elem_start_col_idx = indptr[col_idx];
                     { // process col_idx
                         std::lock_guard<std::mutex> lock_col_idx(mutex1[col_idx]);
-                        row_nnz_col_idx = row_nnz_s[col_idx];
-                        elem_start_col_idx = indptr[col_idx];
                         indices[elem_start_col_idx + row_nnz_col_idx] = kk;
                         row_nnz_s[col_idx] += 1;
 
@@ -179,16 +180,12 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
                     }
                 }
                 if(!compute_values)
-                {
-                    {
-                        std::lock_guard<std::mutex> lock1(mutex2[kk]);
-                        row_nnz += 1;
-                    }
+                {    
+                    #pragma omp atomic
+                    row_nnz += 1;
 
-                    {
-                        std::lock_guard<std::mutex> lock2(mutex2[col_idx]);
-                        row_nnz_s[col_idx] += 1;
-                    }
+                    #pragma omp atomic
+                    row_nnz_s[col_idx] += 1;
                 }
             }
         } // end loop over groups

--- a/fulqrum/core/src/csr.hpp
+++ b/fulqrum/core/src/csr.hpp
@@ -47,11 +47,13 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
     std::vector<uint16_t> grp_max_inds(num_groups, width);
     get_group_max_inds(grp_max_inds, group_offdiag_inds, num_groups);
 
-    // do diagonal first, if any
     std::vector<T> row_nnz_s(subspace_dim, 0);
+    #pragma omp parallel if(subspace_dim > 4096)
+    {
+    // do diagonal first, if any
     if(has_nonzero_diag)
     {
-#pragma omp parallel for if(subspace_dim > 4096)
+        #pragma omp for
         for(kk = 0; kk < subspace_dim; kk++)
         {
             T& row_nnz = row_nnz_s[kk]; // reference T& is critical
@@ -68,7 +70,7 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
         }
     }
 
-#pragma omp parallel for if(subspace_dim > 4096)
+    #pragma omp for
     for(kk = 0; kk < subspace_dim; kk++)
     { // begin loop over all rows
         // define variables locally for omp for loop
@@ -193,6 +195,7 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
             }
         } // end loop over groups
     } // end loop over all rows
+    } // end omp parallel region
 
     if(!compute_values) // Done with all rows so accumulate for correct indptr structure
     {

--- a/fulqrum/core/src/csr.hpp
+++ b/fulqrum/core/src/csr.hpp
@@ -77,172 +77,173 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
 
     // a vector containing the NNZ per row of the matrix
     std::vector<T> row_nnz_s(subspace_dim, 0);
-    #pragma omp parallel if(subspace_dim > 4096)
+#pragma omp parallel if(subspace_dim > 4096)
     {
-    // do diagonal first, if any
-    if(has_nonzero_diag)
-    {
-        #pragma omp for
-        for(kk = 0; kk < subspace_dim; kk++)
+        // do diagonal first, if any
+        if(has_nonzero_diag)
         {
-            T& row_nnz = row_nnz_s[kk]; // reference T& is critical
-            T& elem_start = indptr[kk];
-            if(diag_vec[kk] != 0.0)
+#pragma omp for
+            for(kk = 0; kk < subspace_dim; kk++)
             {
-                if(compute_values)
-                {
-                    indices[elem_start + row_nnz] = kk;
-                    data[elem_start + row_nnz] = diag_vec[kk];
-                }
-                row_nnz += 1;
-            }
-        }
-    }
-
-    // Per-thread scratch buffers, allocated once and reused for all
-    // blocks assigned to this thread (avoids per-row heap allocation).
-    std::vector<uint8_t> rsb_buf; // row_set_bits for BLK rows
-    boost::dynamic_bitset<std::size_t> col_vec(width);
-    const std::size_t num_col_blocks = col_vec.num_blocks();
-
-    #pragma omp for
-    for(std::size_t blk = 0; blk < num_blocks; ++blk)
-    { 
-        const std::size_t r0 = blk * BLK;
-        const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
-        const std::size_t bn = r1 - r0;
-
-        // Build the bit-vector for every row in the block.
-        // Stored contiguously as bn * rsb_w bytes so the
-        // group loop can stride over rows cheaply.
-        rsb_buf.assign(bn * rsb_w, 0);
-        for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-        {
-            const boost::dynamic_bitset<std::size_t>& row =
-                bitsets[r0 + row_in_block].first;
-            uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
-            for(std::size_t b = 0; b < row.num_blocks(); ++b)
-            {
-                std::size_t bits = row.m_bits[b];
-                while(bits != 0)
-                {
-                    int r = __builtin_ctzll(bits);
-                    dst[b * BITS_PER_BLOCK + r] = 1;
-                    bits &= bits - 1;
-                }
-            }
-        }
-
-        for(std::size_t group = 0; group < num_groups; group++)
-        { // begin loop over groups
-            const GroupIndsView group_inds = gview(group);
-            const std::size_t group_start = group_ptrs[group];
-            const std::size_t group_stop = group_ptrs[group + 1];
-            if(group_start >= group_stop)
-                continue;
-
-            const uint16_t max_ind = grp_max_inds[group];
-
-            for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-            {
-                const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
-                // Lower-triangle check: skip upper-triangle elements.
-                // See get_group_max_inds() in offdiag_grouping.hpp.
-                if(!row_set_bits[max_ind])
-                    continue; // continue onto new row
-
-                const std::size_t kk = r0 + row_in_block;
-                const boost::dynamic_bitset<std::size_t>& row = bitsets[kk].first;
-                std::memcpy(col_vec.m_bits.data(),
-                            row.m_bits.data(),
-                            num_col_blocks * sizeof(std::size_t));
-                flip_bits(col_vec, group_inds.data(), group_inds.size());
-
-                std::size_t* col_ptr = subspace.get_ptr(col_vec);
-                if(col_ptr == nullptr)
-                    continue;
-                const std::size_t col_idx = *col_ptr;
-                T row_nnz_col_idx, elem_start_col_idx;
-                T& row_nnz = row_nnz_s[kk];
+                T& row_nnz = row_nnz_s[kk]; // reference T& is critical
                 T& elem_start = indptr[kk];
-                U val= 0;
-                for(std::size_t idx = group_start; idx < group_stop; idx++)
-                { // begin loop over terms in this group
-                    const OperatorTerm_t* term = &terms[idx];
-                    if(passes_proj_validation(term, row))
-                    {
-                        accum_element(row,
-                                    col_vec,
-                                    term->indices,
-                                    term->values,
-                                    term->coeff,
-                                    term->real_phase,
-                                    term->indices.size(),
-                                    val);
-                    }
-                } // end loop over terms in this group
-                if(std::abs(val) > ATOL)
+                if(diag_vec[kk] != 0.0)
                 {
                     if(compute_values)
                     {
-                        #pragma omp atomic write
-                        indices[elem_start + row_nnz] = col_idx;
-                        if constexpr(std::is_same_v<U, double>) // real case
+                        indices[elem_start + row_nnz] = kk;
+                        data[elem_start + row_nnz] = diag_vec[kk];
+                    }
+                    row_nnz += 1;
+                }
+            }
+        }
+
+        // Per-thread scratch buffers, allocated once and reused for all
+        // blocks assigned to this thread (avoids per-row heap allocation).
+        std::vector<uint8_t> rsb_buf; // row_set_bits for BLK rows
+        boost::dynamic_bitset<std::size_t> col_vec(width);
+        const std::size_t num_col_blocks = col_vec.num_blocks();
+
+#pragma omp for
+        for(std::size_t blk = 0; blk < num_blocks; ++blk)
+        {
+            const std::size_t r0 = blk * BLK;
+            const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
+            const std::size_t bn = r1 - r0;
+
+            // Build the bit-vector for every row in the block.
+            // Stored contiguously as bn * rsb_w bytes so the
+            // group loop can stride over rows cheaply.
+            rsb_buf.assign(bn * rsb_w, 0);
+            for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+            {
+                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
+                uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
+                for(std::size_t b = 0; b < row.num_blocks(); ++b)
+                {
+                    std::size_t bits = row.m_bits[b];
+                    while(bits != 0)
+                    {
+                        int r = __builtin_ctzll(bits);
+                        dst[b * BITS_PER_BLOCK + r] = 1;
+                        bits &= bits - 1;
+                    }
+                }
+            }
+
+            for(std::size_t group = 0; group < num_groups; group++)
+            { // begin loop over groups
+                const GroupIndsView group_inds = gview(group);
+                const std::size_t group_start = group_ptrs[group];
+                const std::size_t group_stop = group_ptrs[group + 1];
+                if(group_start >= group_stop)
+                    continue;
+
+                const uint16_t max_ind = grp_max_inds[group];
+
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                {
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                    // Lower-triangle check: skip upper-triangle elements.
+                    // See get_group_max_inds() in offdiag_grouping.hpp.
+                    if(!row_set_bits[max_ind])
+                        continue; // continue onto new row
+
+                    const std::size_t kk = r0 + row_in_block;
+                    const boost::dynamic_bitset<std::size_t>& row = bitsets[kk].first;
+                    std::memcpy(col_vec.m_bits.data(),
+                                row.m_bits.data(),
+                                num_col_blocks * sizeof(std::size_t));
+                    flip_bits(col_vec, group_inds.data(), group_inds.size());
+
+                    std::size_t* col_ptr = subspace.get_ptr(col_vec);
+                    if(col_ptr == nullptr)
+                        continue;
+                    const std::size_t col_idx = *col_ptr;
+                    T row_nnz_col_idx, elem_start_col_idx;
+                    T& row_nnz = row_nnz_s[kk];
+                    T& elem_start = indptr[kk];
+                    U val = 0;
+                    for(std::size_t idx = group_start; idx < group_stop; idx++)
+                    { // begin loop over terms in this group
+                        const OperatorTerm_t* term = &terms[idx];
+                        if(passes_proj_validation(term, row))
                         {
-                            #pragma omp atomic write
-                            data[elem_start + row_nnz] = val;
+                            accum_element(row,
+                                          col_vec,
+                                          term->indices,
+                                          term->values,
+                                          term->coeff,
+                                          term->real_phase,
+                                          term->indices.size(),
+                                          val);
                         }
-                        else // imaginary case
+                    } // end loop over terms in this group
+                    if(std::abs(val) > ATOL)
+                    {
+                        if(compute_values)
                         {
-                            double* __restrict p = reinterpret_cast<double*>(&data[elem_start + row_nnz]);
-                            const double* __restrict q = reinterpret_cast<const double*>(&val);
-                            #pragma omp atomic
-                            p[0] += q[0]; // real part
-                            #pragma omp atomic
-                            p[1] += q[1]; // imag part
-                        }
-                        #pragma omp atomic
-                        row_nnz += 1;
-                        
-                        row_nnz_col_idx = row_nnz_s[col_idx];
-                        elem_start_col_idx = indptr[col_idx];
-                        #pragma omp atomic write
-                        indices[elem_start_col_idx + row_nnz_col_idx] = kk;
-                        #pragma omp atomic
-                        row_nnz_s[col_idx] += 1;
-                        // process col_idx
-                        if constexpr(std::is_same_v<U, double>)
-                        {
-                            #pragma omp atomic write
-                            data[elem_start_col_idx + row_nnz_col_idx] = val;
+#pragma omp atomic write
+                            indices[elem_start + row_nnz] = col_idx;
+                            if constexpr(std::is_same_v<U, double>) // real case
+                            {
+#pragma omp atomic write
+                                data[elem_start + row_nnz] = val;
+                            }
+                            else // imaginary case
+                            {
+                                double* __restrict p =
+                                    reinterpret_cast<double*>(&data[elem_start + row_nnz]);
+                                const double* __restrict q = reinterpret_cast<const double*>(&val);
+#pragma omp atomic
+                                p[0] += q[0]; // real part
+#pragma omp atomic
+                                p[1] += q[1]; // imag part
+                            }
+#pragma omp atomic
+                            row_nnz += 1;
+
+                            row_nnz_col_idx = row_nnz_s[col_idx];
+                            elem_start_col_idx = indptr[col_idx];
+#pragma omp atomic write
+                            indices[elem_start_col_idx + row_nnz_col_idx] = kk;
+#pragma omp atomic
+                            row_nnz_s[col_idx] += 1;
+                            // process col_idx
+                            if constexpr(std::is_same_v<U, double>)
+                            {
+#pragma omp atomic write
+                                data[elem_start_col_idx + row_nnz_col_idx] = val;
+                            }
+                            else
+                            {
+                                // for complex-valued matrix, the upper triangle
+                                // element will be complex conjugate of the lower
+                                // triangle element
+                                const U update_val = std::conj(val);
+                                double* __restrict p2 = reinterpret_cast<double*>(
+                                    &data[elem_start_col_idx + row_nnz_col_idx]);
+                                const double* __restrict q2 =
+                                    reinterpret_cast<const double*>(&update_val);
+#pragma omp atomic write
+                                p2[0] = q2[0]; // real part
+#pragma omp atomic write
+                                p2[1] = q2[1]; // imag part
+                            }
                         }
                         else
                         {
-                            // for complex-valued matrix, the upper triangle
-                            // element will be complex conjugate of the lower
-                            // triangle element
-                            const U update_val = std::conj(val);
-                            double* __restrict p2 = reinterpret_cast<double*>(&data[elem_start_col_idx + row_nnz_col_idx]);
-                            const double* __restrict q2 = reinterpret_cast<const double*>(&update_val);
-                            #pragma omp atomic write
-                            p2[0] = q2[0]; // real part
-                            #pragma omp atomic write
-                            p2[1] = q2[1]; // imag part
-                        }
-                    
-                    }
-                    else
-                    {    
-                        #pragma omp atomic
-                        row_nnz += 1;
+#pragma omp atomic
+                            row_nnz += 1;
 
-                        #pragma omp atomic
-                        row_nnz_s[col_idx] += 1;
+#pragma omp atomic
+                            row_nnz_s[col_idx] += 1;
+                        }
                     }
-                }
-            } // end loop over row block
-        } // end loop over groups
-    } // end loop over all row blocks
+                } // end loop over row block
+            } // end loop over groups
+        } // end loop over all row blocks
     } // end omp parallel region
 
     if(!compute_values) // Done with all rows so accumulate for correct indptr structure

--- a/fulqrum/core/src/matvec.hpp
+++ b/fulqrum/core/src/matvec.hpp
@@ -138,7 +138,7 @@ void omp_matvec(const std::vector<OperatorTerm_t>& terms,
                         // Lower-triangle check: skip upper-triangle elements.
                         // See get_group_max_inds() in offdiag_grouping.hpp.
                         if(!row_set_bits[max_ind])
-                            continue;
+                            continue; // continue onto new row
 
                         const std::size_t kk = r0 + row_in_block;
                         const boost::dynamic_bitset<std::size_t>& row = bitsets[kk].first;

--- a/fulqrum/core/src/matvec.hpp
+++ b/fulqrum/core/src/matvec.hpp
@@ -138,7 +138,7 @@ void omp_matvec(const std::vector<OperatorTerm_t>& terms,
                         // Lower-triangle check: skip upper-triangle elements.
                         // See get_group_max_inds() in offdiag_grouping.hpp.
                         if(!row_set_bits[max_ind])
-                            continue; // continue onto new row
+                            continue;
 
                         const std::size_t kk = r0 + row_in_block;
                         const boost::dynamic_bitset<std::size_t>& row = bitsets[kk].first;

--- a/fulqrum/core/src/version.hpp
+++ b/fulqrum/core/src/version.hpp
@@ -13,5 +13,5 @@
  */
 #pragma once
 
-#define FULQRUM_VERSION "0.2.4"
+#define FULQRUM_VERSION "0.4.1"
 #define JSON_VERSION "1.1"

--- a/fulqrum/test/test_csr.py
+++ b/fulqrum/test/test_csr.py
@@ -356,9 +356,9 @@ def test_csr6a():
 
 def test_csr_nnz_dimer():
     """Validat the NNZ in the CSR output for the dimer"""
-    op = fq.QubitOperator.from_json(PATH+"ch4_dimer_jw.json.xz")
+    op = fq.QubitOperator.from_json(PATH + "ch4_dimer_jw.json.xz")
     op.set_type(1)
-    dist = fq.utils.io.json_to_dict(PATH+"dimer_subspace.json.xz")
+    dist = fq.utils.io.json_to_dict(PATH + "dimer_subspace.json.xz")
     S = fq.Subspace([list(dist.keys())])
     Hsub = fq.SubspaceHamiltonian(op, S)
     A = Hsub.to_csr_linearoperator()

--- a/fulqrum/test/test_csr.py
+++ b/fulqrum/test/test_csr.py
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 # pylint: disable=no-name-in-module
+from pathlib import Path
 import numpy as np
 import scipy.sparse as sp
 import fulqrum as fq
@@ -18,6 +19,8 @@ from fulqrum.utils import qubitoperator_to_matrix
 """All test names ending with `a` uses `use_all_bitset_blocks=False` which
     using first (LSB) block of a bitset for hashing.
 """
+
+PATH = str(Path(__file__).parent) + "/data/"
 
 
 def matrix_subspace(A, rows):
@@ -349,3 +352,14 @@ def test_csr6a():
     assert np.allclose(P.indices, M.indices)
     assert np.allclose(P.data, M.data)
     assert P.indptr.dtype == np.int32
+
+
+def test_csr_nnz_dimer():
+    """Validat the NNZ in the CSR output for the dimer"""
+    op = fq.QubitOperator.from_json(PATH+"ch4_dimer_jw.json.xz")
+    op.set_type(1)
+    dist = fq.utils.io.json_to_dict(PATH+"dimer_subspace.json.xz")
+    S = fq.Subspace([list(dist.keys())])
+    Hsub = fq.SubspaceHamiltonian(op, S)
+    A = Hsub.to_csr_linearoperator()
+    assert A.nnz == 2064834


### PR DESCRIPTION
Ports changes from `matvec.hpp` over to `csr.hpp`.  As before, the code is ~40% faster.  This also fixes a bug in the CSR builder that would break out of all groups rather than continue onto the next if a column vector was found to be outside the subspace

Also bumps micro version due to the bug fix