### PR TITLE
Faster type=1 csrlike builder

### DIFF
--- a/fulqrum/core/src/csr.hpp
+++ b/fulqrum/core/src/csr.hpp
@@ -105,7 +105,7 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
         boost::dynamic_bitset<std::size_t> col_vec(width);
         const std::size_t num_col_blocks = col_vec.num_blocks();
 
-#pragma omp for
+#pragma omp for schedule(dynamic)
         for(std::size_t blk = 0; blk < num_blocks; ++blk)
         {
             const std::size_t r0 = blk * BLK;

--- a/fulqrum/core/src/csr_utils.hpp
+++ b/fulqrum/core/src/csr_utils.hpp
@@ -15,8 +15,7 @@
 #include <boost/sort/pdqsort/pdqsort.hpp>
 #include <complex>
 #include <cstdlib>
-#include <cstring>
-#include <numeric>
+#include <utility>
 #include <vector>
 
 template <typename T, typename U>
@@ -70,34 +69,30 @@ void sort_paired(std::vector<std::vector<T>>& cols, std::vector<std::vector<U>>&
 {
 #pragma omp parallel
     {
-        std::vector<T> tmp1;
-        std::vector<U> tmp2;
-        std::vector<size_t> idx;
+        std::vector<std::pair<T, U>> tmp;
 
 #pragma omp for schedule(dynamic)
-        for(size_t kk = 0; kk < cols.size(); kk++)
+        for(std::size_t kk = 0; kk < cols.size(); kk++)
         {
             auto& row1 = cols[kk];
             auto& row2 = data[kk];
-            const size_t n = row1.size();
+            std::size_t jj;
+            const std::size_t num_elems = row1.size();
 
-            idx.resize(n);
-            tmp1.resize(n);
-            tmp2.resize(n);
-
-            std::iota(idx.begin(), idx.end(), 0);
+            tmp.resize(num_elems);
+            for(jj = 0; jj < num_elems; jj++)
+                tmp[jj] = {row1[jj], row2[jj]};
 
             boost::sort::pdqsort(
-                idx.begin(), idx.end(), [&](size_t a, size_t b) { return row1[a] < row1[b]; });
+                tmp.begin(), tmp.end(), [](const std::pair<T, U>& a, const std::pair<T, U>& b) {
+                    return a.first < b.first;
+                });
 
-            for(size_t i = 0; i < n; i++)
+            for(jj = 0; jj < num_elems; jj++)
             {
-                tmp1[i] = row1[idx[i]];
-                tmp2[i] = row2[idx[i]];
+                row1[jj] = std::move(tmp[jj].first);
+                row2[jj] = std::move(tmp[jj].second);
             }
-
-            memcpy(row1.data(), tmp1.data(), n * sizeof(T));
-            memcpy(row2.data(), tmp2.data(), n * sizeof(U));
         }
     }
 }

--- a/fulqrum/core/src/csrlike_builder.hpp
+++ b/fulqrum/core/src/csrlike_builder.hpp
@@ -51,7 +51,7 @@ void csrlike_builder(const std::vector<OperatorTerm_t>& terms,
     };
     std::vector<PaddedMutex> mutex1(subspace_dim);
 
-   // Flatten group_offdiag_inds from a vector-of-vectors (scattered heap
+    // Flatten group_offdiag_inds from a vector-of-vectors (scattered heap
     // allocations with pointer chasing per group visit) into a single
     // contiguous CSR-like buffer.  The indirection cost was measurable
     // in profiles, especially for large num_groups.
@@ -82,131 +82,130 @@ void csrlike_builder(const std::vector<OperatorTerm_t>& terms,
     const std::size_t rsb_w = width; // one uint8 per qubit
     const std::size_t num_blocks = (subspace_dim + BLK - 1) / BLK;
 
-
 #pragma omp parallel if(subspace_dim > 4096)
-{
-    // Populate diagonal elements first separately
-    if(has_nonzero_diag)
     {
-        #pragma omp for
-        for(kk = 0; kk < subspace_dim; kk++)
-        { // begin loop over all rows
-
-            if(diag_vec[kk] != 0.0)
-            {
-                cols[kk].push_back(kk);
-                data[kk].push_back(diag_vec[kk]);
-            }
-        }
-    }
-    // Per-thread scratch buffers, allocated once and reused for all
-    // blocks assigned to this thread (avoids per-row heap allocation).
-    std::vector<uint8_t> rsb_buf; // row_set_bits for BLK rows
-    boost::dynamic_bitset<std::size_t> col_vec(width);
-    const std::size_t num_col_blocks = col_vec.num_blocks();
-
-    #pragma omp for schedule(dynamic)
-    for(std::size_t blk = 0; blk < num_blocks; ++blk)
-    { // begin loop over all rows
-        const std::size_t r0 = blk * BLK;
-        const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
-        const std::size_t bn = r1 - r0;
-
-        // Build the bit-vector for every row in the block.
-        // Stored contiguously as bn * rsb_w bytes so the
-        // group loop can stride over rows cheaply.
-        rsb_buf.assign(bn * rsb_w, 0);
-        for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+        // Populate diagonal elements first separately
+        if(has_nonzero_diag)
         {
-            const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
-            uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
-            for(std::size_t b = 0; b < row.num_blocks(); ++b)
-            {
-                std::size_t bits = row.m_bits[b];
-                while(bits != 0)
+#pragma omp for
+            for(kk = 0; kk < subspace_dim; kk++)
+            { // begin loop over all rows
+
+                if(diag_vec[kk] != 0.0)
                 {
-                    int r = __builtin_ctzll(bits);
-                    dst[b * BITS_PER_BLOCK + r] = 1;
-                    bits &= bits - 1;
+                    cols[kk].push_back(kk);
+                    data[kk].push_back(diag_vec[kk]);
                 }
             }
         }
+        // Per-thread scratch buffers, allocated once and reused for all
+        // blocks assigned to this thread (avoids per-row heap allocation).
+        std::vector<uint8_t> rsb_buf; // row_set_bits for BLK rows
+        boost::dynamic_bitset<std::size_t> col_vec(width);
+        const std::size_t num_col_blocks = col_vec.num_blocks();
 
-        for(std::size_t group = 0; group < num_groups; group++)
-        { // begin loop over groups
-            const GroupIndsView group_inds = gview(group);
-            const std::size_t group_start = group_ptrs[group];
-            const std::size_t group_stop = group_ptrs[group + 1];
-            if(group_start >= group_stop)
-                continue;
+#pragma omp for schedule(dynamic)
+        for(std::size_t blk = 0; blk < num_blocks; ++blk)
+        { // begin loop over all rows
+            const std::size_t r0 = blk * BLK;
+            const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
+            const std::size_t bn = r1 - r0;
 
-            const uint16_t max_ind = grp_max_inds[group];
-
+            // Build the bit-vector for every row in the block.
+            // Stored contiguously as bn * rsb_w bytes so the
+            // group loop can stride over rows cheaply.
+            rsb_buf.assign(bn * rsb_w, 0);
             for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
             {
-                const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
-                // Lower-triangle check: skip upper-triangle elements.
-                // See get_group_max_inds() in offdiag_grouping.hpp.
-                if(!row_set_bits[max_ind])
-                    continue; // continue onto new row
-
-                const std::size_t kk = r0 + row_in_block;
-                const boost::dynamic_bitset<std::size_t>& row = bitsets[kk].first;
-                std::memcpy(col_vec.m_bits.data(),
-                            row.m_bits.data(),
-                            num_col_blocks * sizeof(std::size_t));
-                flip_bits(col_vec, group_inds.data(), group_inds.size());
-
-                std::size_t* col_ptr = subspace.get_ptr(col_vec);
-                if(col_ptr == nullptr)
-                    continue;
-                const std::size_t col_idx = *col_ptr;
-                T val = 0;
-                for(std::size_t idx = group_start; idx < group_stop; idx++)
-                { // begin loop over terms in this group
-                    const OperatorTerm_t* term = &terms[idx];
-                    if(passes_proj_validation(term, row))
-                    {
-                        accum_element(row,
-                                        col_vec,
-                                        term->indices,
-                                        term->values,
-                                        term->coeff,
-                                        term->real_phase,
-                                        term->indices.size(),
-                                        val);
-                    }
-                }
-                if(std::abs(val) > ATOL)
+                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
+                uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
+                for(std::size_t b = 0; b < row.num_blocks(); ++b)
                 {
-                    // see fulqrum/core/src/csr.hpp for details
-                    // about these Mutex locks
+                    std::size_t bits = row.m_bits[b];
+                    while(bits != 0)
                     {
-                        std::lock_guard<std::mutex> lock_kk(mutex1[kk].m);
-                        cols[kk].push_back(col_idx);
-                        data[kk].push_back(val);
-                    }
-
-                    {
-                        std::lock_guard<std::mutex> lock_col_idx(mutex1[col_idx].m);
-                        cols[col_idx].push_back(kk);
-                        if constexpr(std::is_same_v<T, double>)
-                        {
-                            data[col_idx].push_back(val);
-                        }
-                        else
-                        {
-                            // for complex-valued matrix, the upper triangle
-                            // element will be complex conjugate of the lower
-                            // triangle element
-                            data[col_idx].push_back(std::conj(val));
-                        }
+                        int r = __builtin_ctzll(bits);
+                        dst[b * BITS_PER_BLOCK + r] = 1;
+                        bits &= bits - 1;
                     }
                 }
-            } // end loop rows in block
-        } // end loop over groups
-    } // end loop over all blocks
-} // end parallel region
+            }
+
+            for(std::size_t group = 0; group < num_groups; group++)
+            { // begin loop over groups
+                const GroupIndsView group_inds = gview(group);
+                const std::size_t group_start = group_ptrs[group];
+                const std::size_t group_stop = group_ptrs[group + 1];
+                if(group_start >= group_stop)
+                    continue;
+
+                const uint16_t max_ind = grp_max_inds[group];
+
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                {
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                    // Lower-triangle check: skip upper-triangle elements.
+                    // See get_group_max_inds() in offdiag_grouping.hpp.
+                    if(!row_set_bits[max_ind])
+                        continue; // continue onto new row
+
+                    const std::size_t kk = r0 + row_in_block;
+                    const boost::dynamic_bitset<std::size_t>& row = bitsets[kk].first;
+                    std::memcpy(col_vec.m_bits.data(),
+                                row.m_bits.data(),
+                                num_col_blocks * sizeof(std::size_t));
+                    flip_bits(col_vec, group_inds.data(), group_inds.size());
+
+                    std::size_t* col_ptr = subspace.get_ptr(col_vec);
+                    if(col_ptr == nullptr)
+                        continue;
+                    const std::size_t col_idx = *col_ptr;
+                    T val = 0;
+                    for(std::size_t idx = group_start; idx < group_stop; idx++)
+                    { // begin loop over terms in this group
+                        const OperatorTerm_t* term = &terms[idx];
+                        if(passes_proj_validation(term, row))
+                        {
+                            accum_element(row,
+                                          col_vec,
+                                          term->indices,
+                                          term->values,
+                                          term->coeff,
+                                          term->real_phase,
+                                          term->indices.size(),
+                                          val);
+                        }
+                    }
+                    if(std::abs(val) > ATOL)
+                    {
+                        // see fulqrum/core/src/csr.hpp for details
+                        // about these Mutex locks
+                        {
+                            std::lock_guard<std::mutex> lock_kk(mutex1[kk].m);
+                            cols[kk].push_back(col_idx);
+                            data[kk].push_back(val);
+                        }
+
+                        {
+                            std::lock_guard<std::mutex> lock_col_idx(mutex1[col_idx].m);
+                            cols[col_idx].push_back(kk);
+                            if constexpr(std::is_same_v<T, double>)
+                            {
+                                data[col_idx].push_back(val);
+                            }
+                            else
+                            {
+                                // for complex-valued matrix, the upper triangle
+                                // element will be complex conjugate of the lower
+                                // triangle element
+                                data[col_idx].push_back(std::conj(val));
+                            }
+                        }
+                    }
+                } // end loop rows in block
+            } // end loop over groups
+        } // end loop over all blocks
+    } // end parallel region
 
     sort_paired(cols, data);
 }

--- a/fulqrum/core/src/csrlike_builder.hpp
+++ b/fulqrum/core/src/csrlike_builder.hpp
@@ -51,13 +51,44 @@ void csrlike_builder(const std::vector<OperatorTerm_t>& terms,
     };
     std::vector<PaddedMutex> mutex1(subspace_dim);
 
+   // Flatten group_offdiag_inds from a vector-of-vectors (scattered heap
+    // allocations with pointer chasing per group visit) into a single
+    // contiguous CSR-like buffer.  The indirection cost was measurable
+    // in profiles, especially for large num_groups.
+    std::vector<width_t> _flat_inds;
+    std::vector<std::size_t> _inds_offsets;
+    flatten_offdiag_inds(group_offdiag_inds, _flat_inds, _inds_offsets);
+    const width_t* __restrict flat_inds = _flat_inds.data();
+    const std::size_t* __restrict inds_offsets = _inds_offsets.data();
+    auto gview = [&](std::size_t g) -> GroupIndsView {
+        const std::size_t off = inds_offsets[g];
+        return GroupIndsView{flat_inds + off, inds_offsets[g + 1] - off};
+    };
+
+    // grp_max_inds[g] = the highest bit-flip index for group g.
+    // Used to detect lower-triangle elements without building col_vec.
+    // See get_group_max_inds() in offdiag_grouping.hpp for the rationale.
     std::vector<uint16_t> grp_max_inds(num_groups, width);
     get_group_max_inds(grp_max_inds, group_offdiag_inds, num_groups);
 
+    // Block size for the tiled outer loop.
+    std::size_t BLK = 128;
+    if(const char* _blk_env = std::getenv("FQ_BLK"))
+    {
+        long _blk = std::atol(_blk_env);
+        if(_blk > 0)
+            BLK = static_cast<std::size_t>(_blk);
+    }
+    const std::size_t rsb_w = width; // one uint8 per qubit
+    const std::size_t num_blocks = (subspace_dim + BLK - 1) / BLK;
+
+
+#pragma omp parallel if(subspace_dim > 4096)
+{
     // Populate diagonal elements first separately
     if(has_nonzero_diag)
     {
-#pragma omp parallel for schedule(dynamic) if(subspace_dim > 4096)
+        #pragma omp for
         for(kk = 0; kk < subspace_dim; kk++)
         { // begin loop over all rows
 
@@ -68,96 +99,114 @@ void csrlike_builder(const std::vector<OperatorTerm_t>& terms,
             }
         }
     }
+    // Per-thread scratch buffers, allocated once and reused for all
+    // blocks assigned to this thread (avoids per-row heap allocation).
+    std::vector<uint8_t> rsb_buf; // row_set_bits for BLK rows
+    boost::dynamic_bitset<std::size_t> col_vec(width);
+    const std::size_t num_col_blocks = col_vec.num_blocks();
 
-#pragma omp parallel for if(subspace_dim > 4096)
-    for(kk = 0; kk < subspace_dim; kk++)
+    #pragma omp for schedule(dynamic)
+    for(std::size_t blk = 0; blk < num_blocks; ++blk)
     { // begin loop over all rows
-        // define variables locally for omp for loop
-        std::size_t idx, col_idx;
-        std::size_t group_start, group_stop, group;
-        const OperatorTerm_t* term;
-        const boost::dynamic_bitset<size_t>& row = bitsets[kk].first;
-        boost::dynamic_bitset<std::size_t> col_vec;
-        std::size_t* col_ptr;
-        const std::vector<width_t>* group_inds;
-        T val;
+        const std::size_t r0 = blk * BLK;
+        const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
+        const std::size_t bn = r1 - r0;
 
-        std::vector<uint8_t> row_set_bits(row.size(), 0);
-        bitset_to_bitvec(row, row_set_bits);
+        // Build the bit-vector for every row in the block.
+        // Stored contiguously as bn * rsb_w bytes so the
+        // group loop can stride over rows cheaply.
+        rsb_buf.assign(bn * rsb_w, 0);
+        for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+        {
+            const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
+            uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
+            for(std::size_t b = 0; b < row.num_blocks(); ++b)
+            {
+                std::size_t bits = row.m_bits[b];
+                while(bits != 0)
+                {
+                    int r = __builtin_ctzll(bits);
+                    dst[b * BITS_PER_BLOCK + r] = 1;
+                    bits &= bits - 1;
+                }
+            }
+        }
 
-        for(group = 0; group < num_groups; group++)
+        for(std::size_t group = 0; group < num_groups; group++)
         { // begin loop over groups
-            // Detects a lower or an upper
-            // triangle matrix element.
-            // See details in ``get_group_max_inds()``
-            // in fulqrum/core/src/offdiag_grouping.hpp
-            if(!row_set_bits[grp_max_inds[group]])
-            {
+            const GroupIndsView group_inds = gview(group);
+            const std::size_t group_start = group_ptrs[group];
+            const std::size_t group_stop = group_ptrs[group + 1];
+            if(group_start >= group_stop)
                 continue;
-            }
 
-            group_start = group_ptrs[group];
-            group_stop = group_ptrs[group + 1];
-            val = 0;
+            const uint16_t max_ind = grp_max_inds[group];
 
-            if(group_start < group_stop)
+            for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
             {
-                group_inds = &group_offdiag_inds[group];
-                col_vec = row;
-                flip_bits(col_vec, group_inds->data(), group_inds->size());
+                const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                // Lower-triangle check: skip upper-triangle elements.
+                // See get_group_max_inds() in offdiag_grouping.hpp.
+                if(!row_set_bits[max_ind])
+                    continue; // continue onto new row
 
-                col_ptr = subspace.get_ptr(col_vec);
+                const std::size_t kk = r0 + row_in_block;
+                const boost::dynamic_bitset<std::size_t>& row = bitsets[kk].first;
+                std::memcpy(col_vec.m_bits.data(),
+                            row.m_bits.data(),
+                            num_col_blocks * sizeof(std::size_t));
+                flip_bits(col_vec, group_inds.data(), group_inds.size());
+
+                std::size_t* col_ptr = subspace.get_ptr(col_vec);
                 if(col_ptr == nullptr)
-                {
                     continue;
-                } // column is NOT in the subspace so break group
-                col_idx = *col_ptr;
-            }
-
-            for(idx = group_start; idx < group_stop; idx++)
-            { // begin loop over terms in this group
-
-                term = &terms[idx];
-                if(passes_proj_validation(term, row))
-                {
-                    accum_element(row,
-                                  col_vec,
-                                  term->indices,
-                                  term->values,
-                                  term->coeff,
-                                  term->real_phase,
-                                  term->indices.size(),
-                                  val);
-                }
-            } // end loop over terms in this group
-            if(std::abs(val) > ATOL)
-            {
-                // see fulqrum/core/src/csr.hpp for details
-                // about these Mutex locks
-                {
-                    std::lock_guard<std::mutex> lock_kk(mutex1[kk].m);
-                    cols[kk].push_back(col_idx);
-                    data[kk].push_back(val);
-                }
-
-                {
-                    std::lock_guard<std::mutex> lock_col_idx(mutex1[col_idx].m);
-                    cols[col_idx].push_back(kk);
-                    if constexpr(std::is_same_v<T, double>)
+                const std::size_t col_idx = *col_ptr;
+                T val = 0;
+                for(std::size_t idx = group_start; idx < group_stop; idx++)
+                { // begin loop over terms in this group
+                    const OperatorTerm_t* term = &terms[idx];
+                    if(passes_proj_validation(term, row))
                     {
-                        data[col_idx].push_back(val);
-                    }
-                    else
-                    {
-                        // for complex-valued matrix, the upper triangle
-                        // element will be complex conjugate of the lower
-                        // triangle element
-                        data[col_idx].push_back(std::conj(val));
+                        accum_element(row,
+                                        col_vec,
+                                        term->indices,
+                                        term->values,
+                                        term->coeff,
+                                        term->real_phase,
+                                        term->indices.size(),
+                                        val);
                     }
                 }
-            }
+                if(std::abs(val) > ATOL)
+                {
+                    // see fulqrum/core/src/csr.hpp for details
+                    // about these Mutex locks
+                    {
+                        std::lock_guard<std::mutex> lock_kk(mutex1[kk].m);
+                        cols[kk].push_back(col_idx);
+                        data[kk].push_back(val);
+                    }
+
+                    {
+                        std::lock_guard<std::mutex> lock_col_idx(mutex1[col_idx].m);
+                        cols[col_idx].push_back(kk);
+                        if constexpr(std::is_same_v<T, double>)
+                        {
+                            data[col_idx].push_back(val);
+                        }
+                        else
+                        {
+                            // for complex-valued matrix, the upper triangle
+                            // element will be complex conjugate of the lower
+                            // triangle element
+                            data[col_idx].push_back(std::conj(val));
+                        }
+                    }
+                }
+            } // end loop rows in block
         } // end loop over groups
-    } // end loop over all rows
+    } // end loop over all blocks
+} // end parallel region
 
     sort_paired(cols, data);
 }

--- a/fulqrum/core/src/csrlike_builder.hpp
+++ b/fulqrum/core/src/csrlike_builder.hpp
@@ -44,8 +44,12 @@ void csrlike_builder(const std::vector<OperatorTerm_t>& terms,
 
     cols.resize(subspace_dim);
     data.resize(subspace_dim);
-
-    std::vector<std::mutex> mutex1(subspace_dim);
+    // pad the mutex from 40 -> 64 bytes
+    struct alignas(64) PaddedMutex
+    {
+        std::mutex m;
+    };
+    std::vector<PaddedMutex> mutex1(subspace_dim);
 
     std::vector<uint16_t> grp_max_inds(num_groups, width);
     get_group_max_inds(grp_max_inds, group_offdiag_inds, num_groups);
@@ -131,13 +135,13 @@ void csrlike_builder(const std::vector<OperatorTerm_t>& terms,
                 // see fulqrum/core/src/csr.hpp for details
                 // about these Mutex locks
                 {
-                    std::lock_guard<std::mutex> lock_kk(mutex1[kk]);
+                    std::lock_guard<std::mutex> lock_kk(mutex1[kk].m);
                     cols[kk].push_back(col_idx);
                     data[kk].push_back(val);
                 }
 
                 {
-                    std::lock_guard<std::mutex> lock_col_idx(mutex1[col_idx]);
+                    std::lock_guard<std::mutex> lock_col_idx(mutex1[col_idx].m);
                     cols[col_idx].push_back(kk);
                     if constexpr(std::is_same_v<T, double>)
                     {


### PR DESCRIPTION
Reworks the CSRlike builder for type-1 operators to be ~45% faster than the current one.  `mutex` cannot be removed here because we need to `push_back` to vectors whose size we do not know ahead of time. 