### PR TITLE
Build only unique operator terms when importing from FCIDump

### DIFF
--- a/fulqrum/convert/src/integrals.hpp
+++ b/fulqrum/convert/src/integrals.hpp
@@ -31,8 +31,8 @@ inline std::size_t _flat_index4d(width_t i, width_t j, width_t k, width_t l, wid
 }
 
 template <typename T>
-inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict flat_one_body_integrals,
-                                                      T* __restrict flat_two_body_integrals,
+inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
+                                                      T* __restrict ftbi,
                                                       unsigned int ob_arr_len,
                                                       unsigned int tb_arr_len,
                                                       std::complex<double> constant = 0,
@@ -63,93 +63,134 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict flat_one_bo
     {
         fop->terms.emplace_back(constant);
     }
-    // set capacity of fermi terms to worst case
-    std::size_t capacity = (std::abs(constant) > EQ_TOLERANCE ? 1 : 0)
-                               + 2 * half_num_qubits * half_num_qubits
-                               + 4 * half_num_qubits * half_num_qubits * half_num_qubits * half_num_qubits;
-    fop->terms.reserve(capacity);
-
     std::vector<std::vector<FermionicTerm>> temp_terms;
     temp_terms.resize(half_num_qubits);
-    // reserve worst case for each temp terms
-    for(kk = 0; kk < half_num_qubits; kk++)
-    {
-        temp_terms[kk].reserve(2*half_num_qubits+4*half_num_qubits*half_num_qubits*half_num_qubits);
-    }
 
-    #pragma omp parallel for if(half_num_qubits > 8)
+    #pragma omp parallel for schedule(dynamic) if(half_num_qubits > 8)
     for(p = 0; p < half_num_qubits; p++)
     {
         width_t q, r, s, ii, jj, ll;
-        std::complex<double> temp_one_body, temp_two_body;
+        bool do0, do1, do2, do3;
+        std::complex<double> valob, val01, val23;
         for(q = 0; q < half_num_qubits; q++)
         {
-            temp_one_body = flat_one_body_integrals[_flat_index2d(p, q, half_num_qubits)];
-            if(std::abs(temp_one_body) > EQ_TOLERANCE)
+            valob = fobi[_flat_index2d(p, q, half_num_qubits)];
+            if(std::abs(valob) > EQ_TOLERANCE)
             {
                 // Populate 1-body coefficients. Require p and q have same spin.
                 ii = 2 * p;
                 jj = 2 * q;
-                temp_terms[p].emplace_back(ob_str, std::vector<width_t>{qubit_mapping[ii], qubit_mapping[jj]}, temp_one_body);
+                temp_terms[p].emplace_back(ob_str, std::vector<width_t>{qubit_mapping[ii], qubit_mapping[jj]}, valob);
 
                 ii = 2 * p + 1;
                 jj = 2 * q + 1;
-                temp_terms[p].emplace_back(ob_str, std::vector<width_t>{qubit_mapping[ii], qubit_mapping[jj]}, temp_one_body);
+                temp_terms[p].emplace_back(ob_str, std::vector<width_t>{qubit_mapping[ii], qubit_mapping[jj]}, valob);
+            }
+            if (q < p)
+            {
+                continue;
             }
             // Continue looping to prepare 2-body coefficients.
             for(r = 0; r < half_num_qubits; r++)
             {
                 for(s = 0; s < half_num_qubits; s++)
                 {
-                    temp_two_body =
-                        flat_two_body_integrals[_flat_index4d(p, q, r, s, half_num_qubits)] / 2.0;
-                    if(std::abs(temp_two_body) > EQ_TOLERANCE)
+                    do0 = false;
+                    do1 = false;
+                    do2 = false;
+                    do3 = false;
+
+                    if(p == q)
                     {
-                        // Mixed spin
-                        ii = 2 * p;
-                        jj = 2 * q + 1;
-                        kk = 2 * r + 1;
-                        ll = 2 * s;
-                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
-                                                        qubit_mapping[jj],
-                                                        qubit_mapping[kk],
-                                                        qubit_mapping[ll]}, temp_two_body);
-
-                        ii = 2 * p + 1;
-                        jj = 2 * q;
-                        kk = 2 * r;
-                        ll = 2 * s + 1;
-                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
-                                                        qubit_mapping[jj],
-                                                        qubit_mapping[kk],
-                                                        qubit_mapping[ll]}, temp_two_body);
-
-                        // Same spin
-                        ii = 2 * p;
-                        jj = 2 * q;
-                        kk = 2 * r;
-                        ll = 2 * s;
-                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
-                                                        qubit_mapping[jj],
-                                                        qubit_mapping[kk],
-                                                        qubit_mapping[ll]}, temp_two_body);
-
-                        ii = 2 * p + 1;
-                        jj = 2 * q + 1;
-                        kk = 2 * r + 1;
-                        ll = 2 * s + 1;
-                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
-                                                        qubit_mapping[jj],
-                                                        qubit_mapping[kk],
-                                                        qubit_mapping[ll]}, temp_two_body);
+                        if(s == r)
+                        {
+                            val01 = ftbi[_flat_index4d(p, q, r, s, half_num_qubits)];
+                            do0 = std::abs(val01) > EQ_TOLERANCE;
+                        }
+                        else if(s > r)
+                        {
+                            val01 = 0.5*(ftbi[_flat_index4d(p, q, r, s, half_num_qubits)] + ftbi[_flat_index4d(p, q, s, r, half_num_qubits)]);
+                            do0 = std::abs(val01) > EQ_TOLERANCE;
+                            do1 = do0;
+                        }
                     }
-                }
-            }
-        }
-    }
+                    else
+                    {
+                        if(s == r)
+                        {
+                            val01 = 0.5*(ftbi[_flat_index4d(p, q, r, s, half_num_qubits)] + ftbi[_flat_index4d(q, p, r, s, half_num_qubits)]);
+                            do0 = std::abs(val01) > EQ_TOLERANCE;
+                            do1 = do0;
+                        }
+                        else
+                        {
+                            val01 = 0.5*(ftbi[_flat_index4d(p, q, r, s, half_num_qubits)] + ftbi[_flat_index4d(q, p, s, r, half_num_qubits)]);
+                            do0 = std::abs(val01) > EQ_TOLERANCE;
+                            do1 = do0;
+                            if (s > r)
+                            {
+                                val23 = val01 - 0.5*(ftbi[_flat_index4d(p, q, s, r, half_num_qubits)] + ftbi[_flat_index4d(q, p, r, s, half_num_qubits)]);
+                                do2 = std::abs(val23) > EQ_TOLERANCE;
+                                do3 = do2;
+                            }
+                        }
+                    }
+
+                    if(do0)
+                    {
+                        ii = 2 * p;
+                        jj = 2 * q + 1;
+                        kk = 2 * r + 1;
+                        ll = 2 * s;
+                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
+                                                        qubit_mapping[jj],
+                                                        qubit_mapping[kk],
+                                                        qubit_mapping[ll]}, val01);
+                    }
+                    if(do1)
+                    {
+                        ii = 2 * p + 1;
+                        jj = 2 * q;
+                        kk = 2 * r;
+                        ll = 2 * s + 1;
+                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
+                                                        qubit_mapping[jj],
+                                                        qubit_mapping[kk],
+                                                        qubit_mapping[ll]}, val01);
+                    }
+                    if(do2)
+                    {
+                        ii = 2 * p;
+                        jj = 2 * q;
+                        kk = 2 * r;
+                        ll = 2 * s;
+                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
+                                                        qubit_mapping[jj],
+                                                        qubit_mapping[kk],
+                                                        qubit_mapping[ll]}, val23);
+                    }
+                    if(do3)
+                    {
+                        ii = 2 * p + 1;
+                        jj = 2 * q + 1;
+                        kk = 2 * r + 1;
+                        ll = 2 * s + 1;
+                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
+                                                        qubit_mapping[jj],
+                                                        qubit_mapping[kk],
+                                                        qubit_mapping[ll]}, val23);
+                    }
+                } // end s-loop
+            } // end r-loop
+        } // end q-loop
+    } // end p-loop
     for(auto& item : temp_terms)
+    {
         fop->terms.insert(fop->terms.end(),
                          std::make_move_iterator(item.begin()),
                          std::make_move_iterator(item.end()));
+    }
+    fop->terms.shrink_to_fit();
+    fop->unique_terms = 1; // all the terms are unique by construction
     return *fop;
 }

--- a/fulqrum/convert/src/integrals.hpp
+++ b/fulqrum/convert/src/integrals.hpp
@@ -32,11 +32,11 @@ inline std::size_t _flat_index4d(width_t i, width_t j, width_t k, width_t l, wid
 
 template <typename T>
 inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
-                                                      T* __restrict ftbi,
-                                                      unsigned int ob_arr_len,
-                                                      unsigned int tb_arr_len,
-                                                      std::complex<double> constant = 0,
-                                                      double EQ_TOLERANCE = 1e-12)
+                                                       T* __restrict ftbi,
+                                                       unsigned int ob_arr_len,
+                                                       unsigned int tb_arr_len,
+                                                       std::complex<double> constant = 0,
+                                                       double EQ_TOLERANCE = 1e-12)
 {
     width_t half_num_qubits = std::sqrt(ob_arr_len);
     width_t num_qubits = 2 * half_num_qubits;
@@ -58,7 +58,7 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
         qubit_mapping[kk] = ((!(kk % 2)) * kk / 2) + ((kk % 2) * (kk / 2 + half_num_qubits));
     }
 
-    FermionicOperator * fop = new FermionicOperator(num_qubits);
+    FermionicOperator* fop = new FermionicOperator(num_qubits);
     if(std::abs(constant) > EQ_TOLERANCE)
     {
         fop->terms.emplace_back(constant);
@@ -66,7 +66,7 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
     std::vector<std::vector<FermionicTerm>> temp_terms;
     temp_terms.resize(half_num_qubits);
 
-    #pragma omp parallel for schedule(dynamic) if(half_num_qubits > 8)
+#pragma omp parallel for schedule(dynamic) if(half_num_qubits > 8)
     for(p = 0; p < half_num_qubits; p++)
     {
         width_t q, r, s, ii, jj, ll;
@@ -80,13 +80,15 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
                 // Populate 1-body coefficients. Require p and q have same spin.
                 ii = 2 * p;
                 jj = 2 * q;
-                temp_terms[p].emplace_back(ob_str, std::vector<width_t>{qubit_mapping[ii], qubit_mapping[jj]}, valob);
+                temp_terms[p].emplace_back(
+                    ob_str, std::vector<width_t>{qubit_mapping[ii], qubit_mapping[jj]}, valob);
 
                 ii = 2 * p + 1;
                 jj = 2 * q + 1;
-                temp_terms[p].emplace_back(ob_str, std::vector<width_t>{qubit_mapping[ii], qubit_mapping[jj]}, valob);
+                temp_terms[p].emplace_back(
+                    ob_str, std::vector<width_t>{qubit_mapping[ii], qubit_mapping[jj]}, valob);
             }
-            if (q < p)
+            if(q < p)
             {
                 continue;
             }
@@ -109,7 +111,8 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
                         }
                         else if(s > r)
                         {
-                            val01 = 0.5*(ftbi[_flat_index4d(p, q, r, s, half_num_qubits)] + ftbi[_flat_index4d(p, q, s, r, half_num_qubits)]);
+                            val01 = 0.5 * (ftbi[_flat_index4d(p, q, r, s, half_num_qubits)] +
+                                           ftbi[_flat_index4d(p, q, s, r, half_num_qubits)]);
                             do0 = std::abs(val01) > EQ_TOLERANCE;
                             do1 = do0;
                         }
@@ -118,18 +121,22 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
                     {
                         if(s == r)
                         {
-                            val01 = 0.5*(ftbi[_flat_index4d(p, q, r, s, half_num_qubits)] + ftbi[_flat_index4d(q, p, r, s, half_num_qubits)]);
+                            val01 = 0.5 * (ftbi[_flat_index4d(p, q, r, s, half_num_qubits)] +
+                                           ftbi[_flat_index4d(q, p, r, s, half_num_qubits)]);
                             do0 = std::abs(val01) > EQ_TOLERANCE;
                             do1 = do0;
                         }
                         else
                         {
-                            val01 = 0.5*(ftbi[_flat_index4d(p, q, r, s, half_num_qubits)] + ftbi[_flat_index4d(q, p, s, r, half_num_qubits)]);
+                            val01 = 0.5 * (ftbi[_flat_index4d(p, q, r, s, half_num_qubits)] +
+                                           ftbi[_flat_index4d(q, p, s, r, half_num_qubits)]);
                             do0 = std::abs(val01) > EQ_TOLERANCE;
                             do1 = do0;
-                            if (s > r)
+                            if(s > r)
                             {
-                                val23 = val01 - 0.5*(ftbi[_flat_index4d(p, q, s, r, half_num_qubits)] + ftbi[_flat_index4d(q, p, r, s, half_num_qubits)]);
+                                val23 = val01 -
+                                        0.5 * (ftbi[_flat_index4d(p, q, s, r, half_num_qubits)] +
+                                               ftbi[_flat_index4d(q, p, r, s, half_num_qubits)]);
                                 do2 = std::abs(val23) > EQ_TOLERANCE;
                                 do3 = do2;
                             }
@@ -142,10 +149,12 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
                         jj = 2 * q + 1;
                         kk = 2 * r + 1;
                         ll = 2 * s;
-                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
-                                                        qubit_mapping[jj],
-                                                        qubit_mapping[kk],
-                                                        qubit_mapping[ll]}, val01);
+                        temp_terms[p].emplace_back(tb_str,
+                                                   std::vector<width_t>{qubit_mapping[ii],
+                                                                        qubit_mapping[jj],
+                                                                        qubit_mapping[kk],
+                                                                        qubit_mapping[ll]},
+                                                   val01);
                     }
                     if(do1)
                     {
@@ -153,10 +162,12 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
                         jj = 2 * q;
                         kk = 2 * r;
                         ll = 2 * s + 1;
-                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
-                                                        qubit_mapping[jj],
-                                                        qubit_mapping[kk],
-                                                        qubit_mapping[ll]}, val01);
+                        temp_terms[p].emplace_back(tb_str,
+                                                   std::vector<width_t>{qubit_mapping[ii],
+                                                                        qubit_mapping[jj],
+                                                                        qubit_mapping[kk],
+                                                                        qubit_mapping[ll]},
+                                                   val01);
                     }
                     if(do2)
                     {
@@ -164,10 +175,12 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
                         jj = 2 * q;
                         kk = 2 * r;
                         ll = 2 * s;
-                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
-                                                        qubit_mapping[jj],
-                                                        qubit_mapping[kk],
-                                                        qubit_mapping[ll]}, val23);
+                        temp_terms[p].emplace_back(tb_str,
+                                                   std::vector<width_t>{qubit_mapping[ii],
+                                                                        qubit_mapping[jj],
+                                                                        qubit_mapping[kk],
+                                                                        qubit_mapping[ll]},
+                                                   val23);
                     }
                     if(do3)
                     {
@@ -175,10 +188,12 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
                         jj = 2 * q + 1;
                         kk = 2 * r + 1;
                         ll = 2 * s + 1;
-                        temp_terms[p].emplace_back(tb_str, std::vector<width_t>{qubit_mapping[ii],
-                                                        qubit_mapping[jj],
-                                                        qubit_mapping[kk],
-                                                        qubit_mapping[ll]}, val23);
+                        temp_terms[p].emplace_back(tb_str,
+                                                   std::vector<width_t>{qubit_mapping[ii],
+                                                                        qubit_mapping[jj],
+                                                                        qubit_mapping[kk],
+                                                                        qubit_mapping[ll]},
+                                                   val23);
                     }
                 } // end s-loop
             } // end r-loop
@@ -187,8 +202,8 @@ inline FermionicOperator& pyscf_integrals_to_fermionic(T* __restrict fobi,
     for(auto& item : temp_terms)
     {
         fop->terms.insert(fop->terms.end(),
-                         std::make_move_iterator(item.begin()),
-                         std::make_move_iterator(item.end()));
+                          std::make_move_iterator(item.begin()),
+                          std::make_move_iterator(item.end()));
     }
     fop->terms.shrink_to_fit();
     fop->unique_terms = 1; // all the terms are unique by construction

--- a/fulqrum/core/fermi_operator.pyx
+++ b/fulqrum/core/fermi_operator.pyx
@@ -22,6 +22,7 @@ from .. import __version__ as VERSION
 from .qubit_operator cimport QubitOperator
 from ..utils.io import dict_to_json, json_to_dict
 from ..exceptions import FulqrumError
+from ..convert import fcidump_to_fq_fermionic_op
 
 
 from pathlib import Path
@@ -537,3 +538,7 @@ cdef class FermionicOperator():
         cdef FermionicOperator out = FermionicOperator(1) #dummy width
         out.oper = out.oper.from_json(str(filename))
         return out
+
+    @classmethod
+    def from_fcidump(self, filename):
+        return fcidump_to_fq_fermionic_op(filename)

--- a/fulqrum/core/src/fermi_oper.hpp
+++ b/fulqrum/core/src/fermi_oper.hpp
@@ -414,6 +414,7 @@ typedef struct FermionicOperator
         {
             deflate_term_indices(terms[kk], temp_terms[kk], collapsed_values);
         }
+        out.terms.reserve(this->size());
         for(std::size_t kk = 0; kk < terms.size(); kk++)
         {
             if(temp_terms[kk].coeff != 0.0)
@@ -421,6 +422,7 @@ typedef struct FermionicOperator
                 out.terms.push_back(std::move(temp_terms[kk]));
             }
         }
+        out.terms.shrink_to_fit();
         out.combined = 1;
         return out;
     }

--- a/fulqrum/core/src/fermi_term.hpp
+++ b/fulqrum/core/src/fermi_term.hpp
@@ -256,9 +256,8 @@ inline void deflate_term_indices(const FermionicTerm& term,
                                  const std::vector<int>& collapsed_values)
 {
     const std::size_t num_elems = term.indices.size();
-    FermionicTerm_t new_term;
-    new_term.indices.reserve(num_elems);
-    new_term.values.reserve(num_elems);
+    out_term.indices.reserve(num_elems);
+    out_term.values.reserve(num_elems);
 
     std::size_t num_touched = 0;
     while(num_touched < num_elems)

--- a/fulqrum/test/test_convert.py
+++ b/fulqrum/test/test_convert.py
@@ -165,6 +165,9 @@ def test_integrals_to_fq_fermionic_op():
             fop2 = old_integrals_to_fq_fermionic_op(
                 one_body_integrals=hcore, two_body_integrals=eri
             )
+            fop = fop.combine_repeat_indices()
+            fop2 = fop2.combine_repeat_terms()
+            fop2 = fop2.combine_repeat_indices()
             # A brute force way to check for operator equality
             assert fop.size() == fop2.size()
             num_touched = 0

--- a/fulqrum/test/test_convert.py
+++ b/fulqrum/test/test_convert.py
@@ -183,6 +183,7 @@ def test_integrals_to_fq_fermionic_op():
                         break
                 assert found
             assert num_touched == fop.size()
+            assert fop.size() == fop2.size()
 
 
 @pytest.mark.skip(reason="Not implemented as it uses already tested functions")


### PR DESCRIPTION
Constructs a `FermionicOperator` from an FCIDump file adding only unique terms to the output operator.  The standard Fe4S4 import drops from 5sec -> 2.8sec on my machine. 

On a larger ~34 million term Fe2S2 in the sto-3g basis the JW performance is improved by over 2X because we no longer need to collect repeat terms (still need to combine repeat indices though).  The relative performance is now:

| Package  | Runtime relative to Fulqrum |
| ------------- | ----------------------------------------- |
| Fulqrum (this PR)  | 1x (9sec, down from 20sec)  |
| ffsim (0.0.83)​  | 44x  |
| openfermion (1.8.1)​  | 540x  |
| qrisp (0.9.6)​ | 1253x  |
| cuda-qx (0.6.0)​  | >9600x  |
| pennylane (0.45.1)​  | >9600x  |
| qiskit-fermions (0.1.0)​​  | >9600x   |
| pychemiq (1.1.4)​​  | OOM  |
| qiskit-nature (0.8.0)​​  | OOM  |