### PR TITLE
Fix type2 silent matrix-element drop bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(fulqrum_tests
     test/test_qubit_operator_offdiag.cpp
     test/test_grouping.cpp
     test/test_ladder.cpp
+    test/test_type2_table.cpp
     test/test_fermi.cpp
     test/test_jw.cpp
     test/test_diag.cpp

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ The type-2 build/matvec scripts (`csrlike_builder2`, `csr2`,
 | `FQ_BLK` | `128` | The number of rows in a block of rows. FQ_BLK number of rows reuses a chunk of group_ladder_ptrs. Larger blocks give more reuse but risk overflowing the per-core cache; smaller blocks reduce reuse. `128` is a good middle ground. Values `<= 0` are ignored. |
 | `FQ_LADDER_WIDTH` | `2` | Number of ladder bits used to bucket each group's terms, giving `2^FQ_LADDER_WIDTH` bins per group (so `2` → 4 bins, `4` → 16 bins). |
 
+Both variables tune the speed only. They change no result.
+
 Example: run a workload with a larger row block and finer ladder bucketing:
 
 ```bash

--- a/fulqrum/core/src/constants.hpp
+++ b/fulqrum/core/src/constants.hpp
@@ -33,6 +33,16 @@ const unsigned int BLOCK_SHIFT = BITS_PER_BLOCK - 1;
 typedef std::tuple<std::string, std::vector<width_t>, std::complex<double>> TermData;
 typedef std::tuple<std::string, std::vector<width_t>> OpData;
 
+// The internal operator values, as named constants. Use these names instead of the
+// raw numbers when you read or write ``OperatorTerm::values``.
+inline constexpr unsigned char OPER_VALUE_Z = 0;
+inline constexpr unsigned char OPER_VALUE_PROJ_0 = 1;
+inline constexpr unsigned char OPER_VALUE_PROJ_1 = 2;
+inline constexpr unsigned char OPER_VALUE_X = 3;
+inline constexpr unsigned char OPER_VALUE_Y = 4;
+inline constexpr unsigned char OPER_VALUE_MINUS = 5;
+inline constexpr unsigned char OPER_VALUE_PLUS = 6;
+
 // Maps operator standard char values into continuous values used internally.
 // Unused values are set to 0xFF for clarity that they really do nothing.
 // Mapping: 'Z'=90->0, '0'=48->1, '1'=49->2, 'X'=88->3, 'Y'=89->4, '-'=45->5, '+'=43->6

--- a/fulqrum/core/src/csr2.hpp
+++ b/fulqrum/core/src/csr2.hpp
@@ -17,7 +17,6 @@
 #include <complex>
 #include <cstdint>
 #include <cstdlib>
-#include <unordered_map>
 #include <vector>
 
 #include "external/hash_set8.hpp"
@@ -28,19 +27,19 @@
 #include "constants.hpp"
 #include "elements.hpp"
 #include "offdiag_grouping.hpp"
+#include "type2_group_table.hpp"
 #include <boost/dynamic_bitset.hpp>
 
-// Builds the CSR structure for a subspace Hamiltonian.
+// Builds the CSR structure for a type-2 subspace Hamiltonian.
 //
-// Group handling mirrors csrlike_builder2: groups are bucketed
-// (aa / aaaa / bb / bbbb / aabb / other) and aabb groups whose
-// terms share a single coeff + real_phase use the direct
-// asign*bsign formula instead of the per-term accum_element loop.
-// other and aabb_slow groups are here for safety.
-// They are supposed to be empty.
+// The group handling mirrors csrlike_builder2. See type2_group_table.hpp for the
+// buckets and for the reason each one is correct. This file holds the row loops
+// and the store action only.
 //
 // Called twice: compute_values == 0 counts entries per row and fills indptr;
 // compute_values == 1 fills indices/data using the indptr from the first call.
+// The two calls run the same code in the same order, thus the counts and the
+// writes agree.
 //
 // T is the index type, U is the value type, e.g. (int, complex).
 template <typename T, typename U>
@@ -67,15 +66,8 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
     const auto* bitsets = subspace.get_bitsets();
 
     // See csrlike_builder2.hpp.
-    std::vector<width_t> _flat_inds;
-    std::vector<std::size_t> _inds_offsets;
-    flatten_offdiag_inds(group_offdiag_inds, _flat_inds, _inds_offsets);
-    const width_t* __restrict flat_inds = _flat_inds.data();
-    const std::size_t* __restrict inds_offsets = _inds_offsets.data();
-    auto gview = [&](std::size_t g) -> GroupIndsView {
-        const std::size_t off = inds_offsets[g];
-        return GroupIndsView{flat_inds + off, inds_offsets[g + 1] - off};
-    };
+    const Type2GroupTable table =
+        build_type2_group_table(terms, group_ptrs, group_offdiag_inds, num_groups, width);
 
     // See csrlike_builder2.hpp.
     const std::size_t _ladder_len = static_cast<std::size_t>(num_groups) * ladder_offset + 1;
@@ -85,12 +77,10 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
     {
         _ladder32.resize(_ladder_len);
         for(std::size_t i = 0; i < _ladder_len; ++i)
+        {
             _ladder32[i] = static_cast<std::uint32_t>(group_ladder_ptrs[i]);
+        }
     }
-    const std::uint32_t* __restrict ladder32 = _ladder32.data();
-    auto ladder = [&](std::size_t idx) -> std::size_t {
-        return _ladder_fits ? static_cast<std::size_t>(ladder32[idx]) : group_ladder_ptrs[idx];
-    };
 
     // See csrlike_builder2.hpp.
     std::size_t BLK = 128;
@@ -98,212 +88,50 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
     {
         long _v = std::atol(_blk_env);
         if(_v > 0)
+        {
             BLK = static_cast<std::size_t>(_v);
+        }
     }
     const std::size_t rsb_w = width; // one uint8 per qubit
     const std::size_t num_blocks = (subspace_dim + BLK - 1) / BLK;
 
-    // Categorize groups into buckets based on offdiag indices (mirror of
-    // csrlike_builder2): aa / aaaa / bb / bbbb / aabb / other.  half_width
-    // splits the bitset into the alpha (lower) and beta (upper) sectors.
-    std::vector<std::size_t> aa_groups;
-    std::vector<std::size_t> aaaa_groups;
-    std::vector<std::size_t> bb_groups;
-    std::vector<std::size_t> bbbb_groups;
-    std::vector<std::size_t> aabb_groups;
-    std::vector<std::size_t> other_groups;
-
-    const width_t half_width = width / 2;
-    for(std::size_t g = 0; g < num_groups; g++)
+    // The shared coefficient of each direct group, in the kernel value type.
+    std::vector<U> direct_value(num_groups, U(0));
+    for(const auto& group : table.direct_unpaired_groups)
     {
-        const GroupIndsView inds = gview(g);
-        const std::size_t ind_size = inds.size();
-
-        if(ind_size == 2)
+        direct_value[group] = direct_coeff_as<U>(table.direct_coeff[group]);
+    }
+    for(const auto& entries : table.paired_by_low_pair)
+    {
+        for(const auto& entry : entries)
         {
-            if(inds[1] < half_width)
-            {
-                aa_groups.push_back(g);
-            }
-            else if(inds[0] >= half_width)
-            {
-                bb_groups.push_back(g);
-            }
-            else
-            {
-                other_groups.push_back(g);
-            }
-        }
-        else if(ind_size == 4)
-        {
-            if(inds[3] < half_width)
-            {
-                aaaa_groups.push_back(g);
-            }
-            else if(inds[0] >= half_width)
-            {
-                bbbb_groups.push_back(g);
-            }
-            else if(inds[1] < half_width && inds[2] >= half_width)
-            {
-                aabb_groups.push_back(g);
-            }
-            else
-            {
-                other_groups.push_back(g);
-            }
-        }
-        else
-        {
-            other_groups.push_back(g);
+            direct_value[entry.group] = direct_coeff_as<U>(table.direct_coeff[entry.group]);
         }
     }
 
-    // Partition aabb_groups into a fast path (single coeff + real_phase shared
-    // by all terms in the group -> matrix element evaluates as
-    // aabb_direct[g] * asign * bsign) and a slow fallback path that goes
-    // through accum_element per term.  In csr2 the value type is U.
-    std::vector<U> aabb_direct(num_groups, 0);
-    std::vector<std::size_t> aabb_fast_groups;
-    std::vector<std::size_t> aabb_slow_groups;
-    aabb_fast_groups.reserve(aabb_groups.size());
+    const Type2RowInputs<U> inputs{terms,
+                                   subspace,
+                                   table,
+                                   bitsets,
+                                   direct_value.data(),
+                                   group_rowint_length,
+                                   _ladder32.data(),
+                                   group_ladder_ptrs,
+                                   ladder_offset,
+                                   _ladder_fits};
 
-    for(const auto& g : aabb_groups)
-    {
-        std::size_t group_start = group_ptrs[g];
-        std::size_t group_stop = group_ptrs[g + 1];
-
-        if(group_start >= group_stop)
-        {
-            continue; // Empty group, nothing to emit on either path
-        }
-
-        const OperatorTerm_t& first_term = terms[group_start];
-        std::complex<double> group_coeff = first_term.coeff;
-        int group_real_phase = first_term.real_phase;
-
-        bool fast_eligible = true;
-        for(std::size_t i = group_start; i < group_stop; i++)
-        {
-            const OperatorTerm_t& term = terms[i];
-            if(term.real_phase != group_real_phase || std::abs(term.coeff - group_coeff) > 1e-14)
-            {
-                fast_eligible = false;
-                break;
-            }
-        }
-
-        if(fast_eligible)
-        {
-            if constexpr(std::is_same_v<U, double>)
-            {
-                aabb_direct[g] = group_real_phase * group_coeff.real();
-            }
-            else
-            {
-                aabb_direct[g] = static_cast<U>(group_real_phase) * group_coeff;
-            }
-            aabb_fast_groups.push_back(g);
-        }
-        else
-        {
-            aabb_slow_groups.push_back(g);
-        }
-    }
-
-    // aabb fast-path prefilter setup
-    // See csrlike_builder2.hpp for details.
-    auto region_hash = [&](const boost::dynamic_bitset<std::size_t>& bs,
-                           width_t lo,
-                           width_t hi,
-                           width_t fa,
-                           width_t fb) -> std::uint64_t {
-        const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
-        const std::size_t hi_blk = static_cast<std::size_t>(hi - 1) >> BLOCK_EXPONENT;
-        const std::size_t n_blk = hi_blk - lo_blk + 1;
-        static thread_local std::vector<std::size_t> buf;
-        if(buf.size() < n_blk)
-            buf.resize(n_blk);
-        for(std::size_t b = lo_blk; b <= hi_blk; ++b)
-        {
-            std::size_t w = bs.m_bits[b];
-            if(fa != MAX_WIDTH && (fa >> BLOCK_EXPONENT) == b)
-                w ^= (std::size_t(1) << (fa & BLOCK_SHIFT));
-            if(fb != MAX_WIDTH && (fb >> BLOCK_EXPONENT) == b)
-                w ^= (std::size_t(1) << (fb & BLOCK_SHIFT));
-            if(b == lo_blk)
-                w &= (~std::size_t(0) << (lo & BLOCK_SHIFT));
-            if(b == hi_blk)
-            {
-                const std::size_t off = static_cast<std::size_t>(hi - 1) & BLOCK_SHIFT;
-                w &= (off == BLOCK_SHIFT) ? ~std::size_t(0)
-                                          : (~std::size_t(0) >> (BLOCK_SHIFT - off));
-            }
-            buf[b - lo_blk] = w;
-        }
-        return rapidhashMicro(buf.data(), n_blk * sizeof(std::size_t));
-    };
-
-    emhash8::HashSet<std::uint64_t> alpha_half_hashes;
-    emhash8::HashSet<std::uint64_t> beta_half_hashes;
-    std::vector<std::array<width_t, 2>> a_pairs;
-    std::vector<std::array<width_t, 2>> b_pairs;
-    struct AabbEntry
-    {
-        std::uint32_t b_id;
-        std::size_t g;
-    };
-    std::vector<std::vector<AabbEntry>> aabb_by_alpha;
-
-    if(!aabb_fast_groups.empty())
+    // Prefilter for the direct paired groups. See type2_prefilter_pairs.
+    emhash8::HashSet<std::uint64_t> low_half_set;
+    emhash8::HashSet<std::uint64_t> high_half_set;
+    if(table.has_paired_groups())
     {
         for(std::size_t s = 0; s < subspace_dim; ++s)
         {
             const auto& bs = bitsets[s].first;
-            alpha_half_hashes.insert(region_hash(bs, 0, half_width, MAX_WIDTH, MAX_WIDTH));
-            beta_half_hashes.insert(region_hash(bs, half_width, width, MAX_WIDTH, MAX_WIDTH));
-        }
-
-        std::unordered_map<std::uint32_t, std::uint32_t> a_pair_id;
-        std::unordered_map<std::uint32_t, std::uint32_t> b_pair_id;
-        for(const auto& g : aabb_fast_groups)
-        {
-            const GroupIndsView inds = gview(g);
-            const width_t ap0 = inds[0], ap1 = inds[1], bp0 = inds[2], bp1 = inds[3];
-            const std::uint32_t ak = (std::uint32_t(ap0) << 16) | ap1;
-            const std::uint32_t bk = (std::uint32_t(bp0) << 16) | bp1;
-
-            std::uint32_t a_id;
-            auto ai = a_pair_id.find(ak);
-            if(ai == a_pair_id.end())
-            {
-                a_id = static_cast<std::uint32_t>(a_pairs.size());
-                a_pair_id.emplace(ak, a_id);
-                a_pairs.push_back({ap0, ap1});
-                aabb_by_alpha.emplace_back();
-            }
-            else
-            {
-                a_id = ai->second;
-            }
-
-            std::uint32_t b_id;
-            auto bi = b_pair_id.find(bk);
-            if(bi == b_pair_id.end())
-            {
-                b_id = static_cast<std::uint32_t>(b_pairs.size());
-                b_pair_id.emplace(bk, b_id);
-                b_pairs.push_back({bp0, bp1});
-            }
-            else
-            {
-                b_id = bi->second;
-            }
-            aabb_by_alpha[a_id].push_back({b_id, g});
+            low_half_set.insert(table.half_key(bs, 0, table.split_point));
+            high_half_set.insert(table.half_key(bs, table.split_point, width));
         }
     }
-    const std::size_t num_a_pairs = a_pairs.size();
-    const std::size_t num_b_pairs = b_pairs.size();
 
     // process diagonal
     std::vector<T> row_nnz_s(subspace_dim, 0);
@@ -328,14 +156,15 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
     }
 
     // See csrlike_builder2.hpp for details.
-    const std::size_t rsb_w2 = rsb_w;
 #pragma omp parallel if(subspace_dim > 4096)
     {
         // Per-thread scratch, reused across blocks (no per-block realloc).
         std::vector<uint8_t> rsb_buf;
-        std::vector<char> alpha_ok(num_a_pairs);
-        std::vector<char> beta_ok(num_b_pairs);
+        std::vector<char> low_pair_ok(table.low_pairs.size());
+        std::vector<char> high_pair_ok(table.high_pairs.size());
         boost::dynamic_bitset<std::size_t> col_vec;
+        std::size_t col_idx;
+        U val;
 
 #pragma omp for schedule(dynamic)
         for(std::size_t blk = 0; blk < num_blocks; ++blk)
@@ -344,27 +173,11 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
             const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
             const std::size_t bn = r1 - r0;
 
-            // row_set_bits for every row in the block, contiguous.
-            rsb_buf.assign(bn * rsb_w2, 0);
-            for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-            {
-                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
-                uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w2;
-                for(std::size_t b = 0; b < row.num_blocks(); ++b)
-                {
-                    std::size_t bits = row.m_bits[b];
-                    while(bits != 0)
-                    {
-                        int r = __builtin_ctzll(bits);
-                        dst[b * BITS_PER_BLOCK + r] = 1;
-                        bits &= bits - 1;
-                    }
-                }
-            }
+            fill_block_row_bits(bitsets, r0, bn, rsb_w, rsb_buf);
 
-            // Emit a single (row r0+row_in_block, col_idx, v) entry.
+            // Stores a single (row r0+row_in_block, col_idx, v) entry.
             // row_nnz_s[r0+row_in_block] and indptr[r0+row_in_block] give the CSR write position.
-            auto emit = [&](std::size_t row_in_block, std::size_t cidx, const U& v) {
+            auto store_element = [&](std::size_t row_in_block, std::size_t cidx, const U& v) {
                 T& row_nnz = row_nnz_s[r0 + row_in_block];
                 if(compute_values)
                 {
@@ -375,186 +188,78 @@ void csr_matrix_builder2(const std::vector<OperatorTerm_t>& terms,
                 row_nnz += 1;
             };
 
-            // Standard per-group path for one (group g, row_in_block) pair.
-            auto process_standard_group = [&](std::size_t g, std::size_t row_in_block) {
-                const GroupIndsView group_inds = gview(g);
-                const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w2;
-
-                // Hamming weight check.
-                const width_t _p = group_inds[0];
-                const width_t _q = group_inds[1];
-                if(group_inds.size() == 2)
+            // Standard groups (group-outer, row-inner).
+            for(const auto& g : table.standard_groups)
+            {
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
                 {
-                    if(row_set_bits[_p] == row_set_bits[_q])
-                        return;
-                }
-                else if(group_inds.size() == 4)
-                {
-                    const width_t _r = group_inds[2];
-                    const width_t _s = group_inds[3];
-                    if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] + row_set_bits[_s] !=
-                       2)
-                        return;
-                }
-
-                const unsigned int row_int =
-                    bitset_ladder_int(row_set_bits, group_inds.data(), group_rowint_length[g]);
-                const std::size_t group_int_start = ladder(g * ladder_offset + row_int);
-                const std::size_t group_int_stop = ladder(g * ladder_offset + row_int + 1);
-                if(group_int_start >= group_int_stop)
-                    return;
-
-                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
-                col_vec = row;
-                flip_bits(col_vec, group_inds.data(), group_inds.size());
-
-                std::size_t* col_ptr = subspace.get_ptr(col_vec);
-                if(col_ptr == nullptr)
-                    return;
-                const std::size_t col_idx = *col_ptr;
-
-                U val = 0;
-                for(std::size_t idx = group_int_start; idx < group_int_stop; idx++)
-                {
-                    const OperatorTerm_t* term = &terms[idx];
-                    if(passes_proj_validation(term, row))
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                    if(type2_standard_element(
+                           inputs, r0 + row_in_block, row_set_bits, g, col_vec, col_idx, val))
                     {
-                        accum_element(row,
-                                      col_vec,
-                                      term->indices,
-                                      term->values,
-                                      term->coeff,
-                                      term->real_phase,
-                                      term->indices.size(),
-                                      val);
+                        store_element(row_in_block, col_idx, val);
                     }
                 }
+            }
 
-                if(std::abs(val) > ATOL)
-                    emit(row_in_block, col_idx, val);
-            };
-
-            for(const auto& g : aa_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-            for(const auto& g : aaaa_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-            for(const auto& g : bb_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-
-            // aabb fast path, ROW-major within the block to preserve the per-row
-            // alpha/beta prefilter skip.
-            if(!aabb_fast_groups.empty())
+            // Direct paired groups, ROW-major within the block to preserve the
+            // per-row prefilter skip.
+            if(table.has_paired_groups())
             {
                 for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
                 {
                     const boost::dynamic_bitset<std::size_t>& row =
                         bitsets[r0 + row_in_block].first;
-                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w2;
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                    type2_prefilter_pairs(table,
+                                          row,
+                                          row_set_bits,
+                                          low_half_set,
+                                          high_half_set,
+                                          width,
+                                          low_pair_ok.data(),
+                                          high_pair_ok.data());
 
-                    auto range_parity = [&](width_t lo, width_t hi) -> std::size_t {
-                        if(lo >= hi)
-                            return 0;
-                        const width_t last = hi - 1; // inclusive last bit
-                        const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
-                        const std::size_t hi_blk = static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
-                        const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
-                        const std::size_t hi_mask =
-                            ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
-                        std::size_t acc;
-                        if(lo_blk == hi_blk)
-                        {
-                            acc = row.m_bits[lo_blk] & lo_mask & hi_mask;
-                        }
-                        else
-                        {
-                            acc = row.m_bits[lo_blk] & lo_mask;
-                            for(std::size_t b = lo_blk + 1; b < hi_blk; b++)
-                                acc ^= row.m_bits[b];
-                            acc ^= row.m_bits[hi_blk] & hi_mask;
-                        }
-                        return static_cast<std::size_t>(
-                            __builtin_parityll(static_cast<unsigned long long>(acc)));
-                    };
-
-                    for(std::size_t i = 0; i < num_a_pairs; ++i)
+                    for(std::size_t i = 0; i < table.low_pairs.size(); ++i)
                     {
-                        const width_t p0 = a_pairs[i][0];
-                        const width_t p1 = a_pairs[i][1];
-                        if(row_set_bits[p0] == row_set_bits[p1])
+                        if(!low_pair_ok[i])
                         {
-                            alpha_ok[i] = 0;
                             continue;
                         }
-                        alpha_ok[i] =
-                            alpha_half_hashes.contains(region_hash(row, 0, half_width, p0, p1));
-                    }
-                    for(std::size_t j = 0; j < num_b_pairs; ++j)
-                    {
-                        const width_t p0 = b_pairs[j][0];
-                        const width_t p1 = b_pairs[j][1];
-                        if(row_set_bits[p0] == row_set_bits[p1])
+                        for(const auto& entry : table.paired_by_low_pair[i])
                         {
-                            beta_ok[j] = 0;
-                            continue;
-                        }
-                        beta_ok[j] =
-                            beta_half_hashes.contains(region_hash(row, half_width, width, p0, p1));
-                    }
-
-                    for(std::size_t i = 0; i < num_a_pairs; ++i)
-                    {
-                        if(!alpha_ok[i])
-                            continue;
-                        const width_t ap0 = a_pairs[i][0];
-                        const width_t ap1 = a_pairs[i][1];
-                        for(const auto& e : aabb_by_alpha[i])
-                        {
-                            if(!beta_ok[e.b_id])
+                            if(!high_pair_ok[entry.high_pair_id])
+                            {
                                 continue;
-                            const GroupIndsView group_inds = gview(e.g);
-                            const width_t bp0 = group_inds[2];
-                            const width_t bp1 = group_inds[3];
-
-                            const unsigned int row_int = bitset_ladder_int(
-                                row_set_bits, group_inds.data(), group_rowint_length[e.g]);
-                            const std::size_t group_int_start =
-                                ladder(e.g * ladder_offset + row_int);
-                            const std::size_t group_int_stop =
-                                ladder(e.g * ladder_offset + row_int + 1);
-                            if(group_int_start >= group_int_stop)
-                                continue;
-
-                            col_vec = row;
-                            flip_bits(col_vec, group_inds.data(), group_inds.size());
-                            std::size_t* col_ptr = subspace.get_ptr(col_vec);
-                            if(col_ptr == nullptr)
-                                continue;
-                            const std::size_t col_idx = *col_ptr;
-
-                            const std::size_t aabb_parity =
-                                range_parity(ap0 + 1, ap1) ^ range_parity(bp0 + 1, bp1);
-                            double sign = aabb_parity ? -1.0 : 1.0;
-                            U val = aabb_direct[e.g] * static_cast<U>(sign);
-
-                            if(std::abs(val) > ATOL)
-                                emit(row_in_block, col_idx, val);
+                            }
+                            if(type2_direct_element(inputs,
+                                                    r0 + row_in_block,
+                                                    row_set_bits,
+                                                    entry.group,
+                                                    col_vec,
+                                                    col_idx,
+                                                    val))
+                            {
+                                store_element(row_in_block, col_idx, val);
+                            }
                         }
                     }
                 }
             }
 
-            for(const auto& g : aabb_slow_groups)
+            // Direct groups that do not split two and two (group-outer, row-inner).
+            for(const auto& g : table.direct_unpaired_groups)
+            {
                 for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-            for(const auto& g : bbbb_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-            for(const auto& g : other_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
+                {
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                    if(type2_direct_element(
+                           inputs, r0 + row_in_block, row_set_bits, g, col_vec, col_idx, val))
+                    {
+                        store_element(row_in_block, col_idx, val);
+                    }
+                }
+            }
         } // end loop over blocks
     } // end parallel region
 

--- a/fulqrum/core/src/csrlike_builder2.hpp
+++ b/fulqrum/core/src/csrlike_builder2.hpp
@@ -17,7 +17,6 @@
 #include <complex>
 #include <cstdint>
 #include <cstdlib>
-#include <unordered_map>
 #include <vector>
 
 #include "external/hash_set8.hpp"
@@ -30,8 +29,21 @@
 #include "csrlike.hpp"
 #include "elements.hpp"
 #include "offdiag_grouping.hpp"
+#include "type2_group_table.hpp"
 #include <boost/dynamic_bitset.hpp>
 
+// Builds the CSR-like structure for a type-2 subspace Hamiltonian.
+//
+// ``build_type2_group_table`` sorts the off-diagonal groups into buckets and
+// builds the look-up tables. ``type2_standard_element`` and ``type2_direct_element``
+//  evaluate one group for one row. See type2_group_table.hpp for the buckets.
+//
+//  (1) standard groups: ``accum_element`` evaluates the element term by term.
+//  (2) direct groups: The element is ``coeff * sign``, where the sign comes from
+//      the parity between two consecutive ladder operators. A direct group that
+//      has two flips in each half of the bitset also uses the half-key prefilter
+//      for early reject.
+//
 // T is the data type, U is in the index type, e.g (complex, int)
 template <typename T, typename U>
 void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
@@ -52,26 +64,16 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
     std::size_t kk;
     const auto* bitsets = subspace.get_bitsets();
 
-    // Flatten group_offdiag_inds (vector<vector> -> contiguous CSR) once.
-    // Inner vec in a 2D vector can be scattered across the heap. Contiguos CSR
-    // has more favorable memory access pattern. Shows decent speed-up in tests.
-    // The one-time flatten is negligible. Output is unchanged.
-    std::vector<width_t> _flat_inds;
-    std::vector<std::size_t> _inds_offsets;
-    flatten_offdiag_inds(group_offdiag_inds, _flat_inds, _inds_offsets);
-    const width_t* __restrict flat_inds = _flat_inds.data();
-    const std::size_t* __restrict inds_offsets = _inds_offsets.data();
-    auto gview = [&](std::size_t g) -> GroupIndsView {
-        const std::size_t off = inds_offsets[g];
-        return GroupIndsView{flat_inds + off, inds_offsets[g + 1] - off};
-    };
+    // Sort the groups into buckets and build the look-up tables. The table also
+    // flattens group_offdiag_inds into one contiguous array.
+    const Type2GroupTable table =
+        build_type2_group_table(terms, group_ptrs, group_offdiag_inds, num_groups, width);
 
     // Make ladder table leaner: size_t -> uint32 once.
     // A lean table is more cache-friendly.
     // Any reasonable operator will have <= UINT32_MAX terms.
     // For the (very unlikely) > 2^32-term operator we skip the lean table
-    // and read the original size_t table via ladder(), so we never silently
-    // truncate an offset.
+    // and read the original size_t table, so we never silently truncate an offset.
     const std::size_t _ladder_len = num_groups * ladder_offset + 1;
     const bool _ladder_fits = terms.size() <= UINT32_MAX;
     std::vector<std::uint32_t> _ladder32;
@@ -79,13 +81,10 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
     {
         _ladder32.resize(_ladder_len);
         for(std::size_t i = 0; i < _ladder_len; ++i)
+        {
             _ladder32[i] = static_cast<std::uint32_t>(group_ladder_ptrs[i]);
+        }
     }
-    const std::uint32_t* __restrict ladder32 = _ladder32.data();
-
-    auto ladder = [&](std::size_t idx) -> std::size_t {
-        return _ladder_fits ? static_cast<std::size_t>(ladder32[idx]) : group_ladder_ptrs[idx];
-    };
 
     // BLK defines number of rows that we process per group in one iter.
     // Group middle x block of rows inner iteration order cut down cache misses
@@ -97,227 +96,51 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
     {
         long _blk = std::atol(_blk_env);
         if(_blk > 0)
+        {
             BLK = static_cast<std::size_t>(_blk);
+        }
     }
 
     cols.resize(subspace_dim);
     data.resize(subspace_dim);
 
-    // Categorize groups into 5 buckets based on offdiag indices
-    std::vector<std::size_t> aa_groups;
-    std::vector<std::size_t> aaaa_groups;
-    std::vector<std::size_t> bb_groups;
-    std::vector<std::size_t> bbbb_groups;
-    std::vector<std::size_t> aabb_groups;
-    std::vector<std::size_t> other_groups; // Groups that don't fit the 5 categories
-
-    const width_t half_width = width / 2;
-    for(std::size_t g = 0; g < num_groups; g++)
+    // The shared coefficient of each direct group.
+    std::vector<T> direct_value(num_groups, T(0));
+    for(const auto& group : table.direct_unpaired_groups)
     {
-        const GroupIndsView inds = gview(g);
-        const std::size_t ind_size = inds.size();
-
-        if(ind_size == 2)
+        direct_value[group] = direct_coeff_as<T>(table.direct_coeff[group]);
+    }
+    for(const auto& entries : table.paired_by_low_pair)
+    {
+        for(const auto& entry : entries)
         {
-            // Check if both indices are in alpha half (aa) or beta half (bb)
-            if(inds[1] < half_width)
-            {
-                aa_groups.push_back(g);
-            }
-            else if(inds[0] >= half_width)
-            {
-                bb_groups.push_back(g);
-            }
-            else
-            {
-                // Mixed case: one index < half_width, one >= half_width
-                other_groups.push_back(g);
-            }
-        }
-        else if(ind_size == 4)
-        {
-            // Check if all 4 indices are in alpha half (aaaa), beta half (bbbb), or split (aabb)
-            if(inds[3] < half_width)
-            {
-                aaaa_groups.push_back(g);
-            }
-            else if(inds[0] >= half_width)
-            {
-                bbbb_groups.push_back(g);
-            }
-            else if(inds[1] < half_width && inds[2] >= half_width)
-            {
-                aabb_groups.push_back(g);
-            }
-            else
-            {
-                // Other 4-index patterns
-                other_groups.push_back(g);
-            }
-        }
-        else
-        {
-            // Groups with sizes other than 2 or 4
-            other_groups.push_back(g);
+            direct_value[entry.group] = direct_coeff_as<T>(table.direct_coeff[entry.group]);
         }
     }
 
-    // Partition aabb_groups into a fast path (single coeff + real_phase shared
-    // by all terms in the group -> matrix element evaluates as
-    // aabb_direct[g] * asign * bsign) and a slow fallback path that goes
-    // through accum_element per term.  aabb_direct is only meaningful for
-    // groups in aabb_fast_groups; aabb_slow_groups read it as zero.
-    std::vector<T> aabb_direct(num_groups, 0);
-    std::vector<std::size_t> aabb_fast_groups;
-    std::vector<std::size_t> aabb_slow_groups;
-    aabb_fast_groups.reserve(aabb_groups.size());
+    const Type2RowInputs<T> inputs{terms,
+                                   subspace,
+                                   table,
+                                   bitsets,
+                                   direct_value.data(),
+                                   group_rowint_length,
+                                   _ladder32.data(),
+                                   group_ladder_ptrs,
+                                   ladder_offset,
+                                   _ladder_fits};
 
-    for(const auto& g : aabb_groups)
-    {
-        std::size_t group_start = group_ptrs[g];
-        std::size_t group_stop = group_ptrs[g + 1];
-
-        if(group_start >= group_stop)
-        {
-            continue; // Empty group, nothing to emit on either path
-        }
-
-        const OperatorTerm_t& first_term = terms[group_start];
-        std::complex<double> group_coeff = first_term.coeff;
-        int group_real_phase = first_term.real_phase;
-
-        bool fast_eligible = true;
-        for(std::size_t idx = group_start; idx < group_stop; idx++)
-        {
-            const OperatorTerm_t& term = terms[idx];
-            if(term.real_phase != group_real_phase || std::abs(term.coeff - group_coeff) > 1e-14)
-            {
-                fast_eligible = false;
-                break;
-            }
-        }
-
-        if(fast_eligible)
-        {
-            if constexpr(std::is_same_v<T, double>)
-            {
-                aabb_direct[g] = group_real_phase * group_coeff.real();
-            }
-            else
-            {
-                aabb_direct[g] = static_cast<T>(group_real_phase) * group_coeff;
-            }
-            aabb_fast_groups.push_back(g);
-        }
-        else
-        {
-            aabb_slow_groups.push_back(g);
-        }
-    }
-
-    // aabb fast-path prefilter setup
-    // The aabb hot loop is O(subspace_dim * num_aabb_groups) with mostly misses
-    // (most columns are not in the subspace).
-    //
-    // An aabb group flips two alpha bits and two beta bits, so the flipped column's
-    // alpha half must equal some subspace element's alpha half AND its beta
-    // half must equal some subspace element's beta half.
-    //
-    // We hash each half and, per row, evaluate the condition once
-    // per unique alpha pair (alpha group inds, aa) and beta pair (beta group inds, bb)
-    // instead of once per group. aabb groups are then visited grouped by alpha pair,
-    // so a failing alpha pair skips all its groups without touching the subspace hash map.
-    auto region_hash = [&](const boost::dynamic_bitset<std::size_t>& bs,
-                           width_t lo,
-                           width_t hi,
-                           width_t fa,
-                           width_t fb) -> std::uint64_t {
-        const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
-        const std::size_t hi_blk = static_cast<std::size_t>(hi - 1) >> BLOCK_EXPONENT;
-        const std::size_t n_blk = hi_blk - lo_blk + 1;
-        static thread_local std::vector<std::size_t> buf;
-        if(buf.size() < n_blk)
-            buf.resize(n_blk);
-        for(std::size_t b = lo_blk; b <= hi_blk; ++b)
-        {
-            std::size_t w = bs.m_bits[b];
-            if(fa != MAX_WIDTH && (fa >> BLOCK_EXPONENT) == b)
-                w ^= (std::size_t(1) << (fa & BLOCK_SHIFT));
-            if(fb != MAX_WIDTH && (fb >> BLOCK_EXPONENT) == b)
-                w ^= (std::size_t(1) << (fb & BLOCK_SHIFT));
-            if(b == lo_blk)
-                w &= (~std::size_t(0) << (lo & BLOCK_SHIFT));
-            if(b == hi_blk)
-            {
-                const std::size_t off = static_cast<std::size_t>(hi - 1) & BLOCK_SHIFT;
-                w &= (off == BLOCK_SHIFT) ? ~std::size_t(0)
-                                          : (~std::size_t(0) >> (BLOCK_SHIFT - off));
-            }
-            buf[b - lo_blk] = w;
-        }
-        return rapidhashMicro(buf.data(), n_blk * sizeof(std::size_t));
-    };
-
-    emhash8::HashSet<std::uint64_t> alpha_half_hashes;
-    emhash8::HashSet<std::uint64_t> beta_half_hashes;
-    std::vector<std::array<width_t, 2>> a_pairs;
-    std::vector<std::array<width_t, 2>> b_pairs;
-    struct AabbEntry
-    {
-        std::uint32_t b_id;
-        std::size_t g;
-    };
-    std::vector<std::vector<AabbEntry>> aabb_by_alpha;
-
-    if(!aabb_fast_groups.empty())
+    // Prefilter for the direct paired groups. See type2_prefilter_pairs.
+    emhash8::HashSet<std::uint64_t> low_half_set;
+    emhash8::HashSet<std::uint64_t> high_half_set;
+    if(table.has_paired_groups())
     {
         for(std::size_t s = 0; s < subspace_dim; ++s)
         {
             const auto& bs = bitsets[s].first;
-            alpha_half_hashes.insert(region_hash(bs, 0, half_width, MAX_WIDTH, MAX_WIDTH));
-            beta_half_hashes.insert(region_hash(bs, half_width, width, MAX_WIDTH, MAX_WIDTH));
-        }
-
-        std::unordered_map<std::uint32_t, std::uint32_t> a_pair_id;
-        std::unordered_map<std::uint32_t, std::uint32_t> b_pair_id;
-        for(const auto& g : aabb_fast_groups)
-        {
-            const GroupIndsView inds = gview(g);
-            const width_t ap0 = inds[0], ap1 = inds[1], bp0 = inds[2], bp1 = inds[3];
-            const std::uint32_t ak = (std::uint32_t(ap0) << 16) | ap1;
-            const std::uint32_t bk = (std::uint32_t(bp0) << 16) | bp1;
-
-            std::uint32_t a_id;
-            auto ai = a_pair_id.find(ak);
-            if(ai == a_pair_id.end())
-            {
-                a_id = static_cast<std::uint32_t>(a_pairs.size());
-                a_pair_id.emplace(ak, a_id);
-                a_pairs.push_back({ap0, ap1});
-                aabb_by_alpha.emplace_back();
-            }
-            else
-            {
-                a_id = ai->second;
-            }
-
-            std::uint32_t b_id;
-            auto bi = b_pair_id.find(bk);
-            if(bi == b_pair_id.end())
-            {
-                b_id = static_cast<std::uint32_t>(b_pairs.size());
-                b_pair_id.emplace(bk, b_id);
-                b_pairs.push_back({bp0, bp1});
-            }
-            else
-            {
-                b_id = bi->second;
-            }
-            aabb_by_alpha[a_id].push_back({b_id, g});
+            low_half_set.insert(table.half_key(bs, 0, table.split_point));
+            high_half_set.insert(table.half_key(bs, table.split_point, width));
         }
     }
-    const std::size_t num_a_pairs = a_pairs.size();
-    const std::size_t num_b_pairs = b_pairs.size();
 
     // Populate diagonal elements first separately
     if(has_nonzero_diag)
@@ -348,11 +171,13 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
     // while being cache resident.
 #pragma omp parallel if(subspace_dim > 4096)
     {
-        // Per-thread scratch, reused across blocks (no per-block realloc).
+        // Per-thread, reused across blocks.
         std::vector<uint8_t> rsb_buf;
-        std::vector<char> alpha_ok(num_a_pairs);
-        std::vector<char> beta_ok(num_b_pairs);
+        std::vector<char> low_pair_ok(table.low_pairs.size());
+        std::vector<char> high_pair_ok(table.high_pairs.size());
         boost::dynamic_bitset<std::size_t> col_vec;
+        std::size_t col_idx;
+        T val;
 
 #pragma omp for schedule(dynamic)
         for(std::size_t blk = 0; blk < num_blocks; ++blk)
@@ -361,194 +186,59 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
             const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
             const std::size_t bn = r1 - r0;
 
-            // row_set_bits for every row in the block, 1D contiguous vec.
-            rsb_buf.assign(bn * rsb_w, 0);
-            for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+            fill_block_row_bits(bitsets, r0, bn, rsb_w, rsb_buf);
+
+            // Standard groups.
+            for(const auto& g : table.standard_groups)
             {
-                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
-                uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
-                for(std::size_t b = 0; b < row.num_blocks(); ++b)
+                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
                 {
-                    std::size_t bits = row.m_bits[b];
-                    while(bits != 0)
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                    if(type2_standard_element(
+                           inputs, r0 + row_in_block, row_set_bits, g, col_vec, col_idx, val))
                     {
-                        int r = __builtin_ctzll(bits);
-                        dst[b * BITS_PER_BLOCK + r] = 1;
-                        bits &= bits - 1;
+                        cols[r0 + row_in_block].push_back(col_idx);
+                        data[r0 + row_in_block].push_back(val);
                     }
                 }
             }
 
-            // Standard per-group path for one (group g, row_in_block) pair.
-            auto process_standard_group = [&](std::size_t g, std::size_t row_in_block) {
-                const GroupIndsView group_inds = gview(g);
-                const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
-
-                // Hamming weight check.
-                const width_t _p = group_inds[0];
-                const width_t _q = group_inds[1];
-                if(group_inds.size() == 2)
-                {
-                    if(row_set_bits[_p] == row_set_bits[_q])
-                        return;
-                }
-                else if(group_inds.size() == 4)
-                {
-                    const width_t _r = group_inds[2];
-                    const width_t _s = group_inds[3];
-                    if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] + row_set_bits[_s] !=
-                       2)
-                        return;
-                }
-
-                const unsigned int row_int =
-                    bitset_ladder_int(row_set_bits, group_inds.data(), group_rowint_length[g]);
-                const std::size_t group_int_start = ladder(g * ladder_offset + row_int);
-                const std::size_t group_int_stop = ladder(g * ladder_offset + row_int + 1);
-                if(group_int_start >= group_int_stop)
-                    return;
-
-                const boost::dynamic_bitset<std::size_t>& row = bitsets[r0 + row_in_block].first;
-                col_vec = row;
-                flip_bits(col_vec, group_inds.data(), group_inds.size());
-
-                std::size_t* col_ptr = subspace.get_ptr(col_vec);
-                if(col_ptr == nullptr)
-                    return;
-                const std::size_t col_idx = *col_ptr;
-
-                T val = 0;
-                for(std::size_t idx = group_int_start; idx < group_int_stop; idx++)
-                {
-                    const OperatorTerm_t* term = &terms[idx];
-                    if(passes_proj_validation(term, row))
-                    {
-                        accum_element(row,
-                                      col_vec,
-                                      term->indices,
-                                      term->values,
-                                      term->coeff,
-                                      term->real_phase,
-                                      term->indices.size(),
-                                      val);
-                    }
-                }
-
-                if(std::abs(val) > ATOL)
-                {
-                    cols[r0 + row_in_block].push_back(col_idx);
-                    data[r0 + row_in_block].push_back(val);
-                }
-            };
-
-            // aa / aaaa / bb (group-outer, row-inner).
-            for(const auto& g : aa_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-            for(const auto& g : aaaa_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-            for(const auto& g : bb_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-
-            // aabb fast path, ROW-major within the block to preserve the
-            // per-row alpha/beta prefilter skip (a failing alpha pair drops all
-            // its groups at once).
-            if(!aabb_fast_groups.empty())
+            // Direct paired groups.
+            if(table.has_paired_groups())
             {
                 for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
                 {
                     const boost::dynamic_bitset<std::size_t>& row =
                         bitsets[r0 + row_in_block].first;
                     const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                    type2_prefilter_pairs(table,
+                                          row,
+                                          row_set_bits,
+                                          low_half_set,
+                                          high_half_set,
+                                          width,
+                                          low_pair_ok.data(),
+                                          high_pair_ok.data());
 
-                    auto range_parity = [&](width_t lo, width_t hi) -> std::size_t {
-                        if(lo >= hi)
-                            return 0;
-                        const width_t last = hi - 1; // inclusive last bit
-                        const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
-                        const std::size_t hi_blk = static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
-                        const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
-                        const std::size_t hi_mask =
-                            ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
-                        std::size_t acc;
-                        if(lo_blk == hi_blk)
-                        {
-                            acc = row.m_bits[lo_blk] & lo_mask & hi_mask;
-                        }
-                        else
-                        {
-                            acc = row.m_bits[lo_blk] & lo_mask;
-                            for(std::size_t b = lo_blk + 1; b < hi_blk; b++)
-                                acc ^= row.m_bits[b];
-                            acc ^= row.m_bits[hi_blk] & hi_mask;
-                        }
-                        return static_cast<std::size_t>(
-                            __builtin_parityll(static_cast<unsigned long long>(acc)));
-                    };
-
-                    for(std::size_t i = 0; i < num_a_pairs; ++i)
+                    for(std::size_t i = 0; i < table.low_pairs.size(); ++i)
                     {
-                        const width_t p0 = a_pairs[i][0];
-                        const width_t p1 = a_pairs[i][1];
-                        if(row_set_bits[p0] == row_set_bits[p1])
+                        if(!low_pair_ok[i])
                         {
-                            alpha_ok[i] = 0;
                             continue;
                         }
-                        alpha_ok[i] =
-                            alpha_half_hashes.contains(region_hash(row, 0, half_width, p0, p1));
-                    }
-                    for(std::size_t j = 0; j < num_b_pairs; ++j)
-                    {
-                        const width_t p0 = b_pairs[j][0];
-                        const width_t p1 = b_pairs[j][1];
-                        if(row_set_bits[p0] == row_set_bits[p1])
+                        for(const auto& entry : table.paired_by_low_pair[i])
                         {
-                            beta_ok[j] = 0;
-                            continue;
-                        }
-                        beta_ok[j] =
-                            beta_half_hashes.contains(region_hash(row, half_width, width, p0, p1));
-                    }
-
-                    for(std::size_t i = 0; i < num_a_pairs; ++i)
-                    {
-                        if(!alpha_ok[i])
-                            continue;
-                        const width_t ap0 = a_pairs[i][0];
-                        const width_t ap1 = a_pairs[i][1];
-                        for(const auto& e : aabb_by_alpha[i])
-                        {
-                            if(!beta_ok[e.b_id])
+                            if(!high_pair_ok[entry.high_pair_id])
+                            {
                                 continue;
-                            const GroupIndsView group_inds = gview(e.g);
-                            const width_t bp0 = group_inds[2];
-                            const width_t bp1 = group_inds[3];
-
-                            const unsigned int row_int = bitset_ladder_int(
-                                row_set_bits, group_inds.data(), group_rowint_length[e.g]);
-                            const std::size_t group_int_start =
-                                ladder(e.g * ladder_offset + row_int);
-                            const std::size_t group_int_stop =
-                                ladder(e.g * ladder_offset + row_int + 1);
-                            if(group_int_start >= group_int_stop)
-                                continue;
-
-                            col_vec = row;
-                            flip_bits(col_vec, group_inds.data(), group_inds.size());
-                            std::size_t* col_ptr = subspace.get_ptr(col_vec);
-                            if(col_ptr == nullptr)
-                                continue;
-                            const std::size_t col_idx = *col_ptr;
-
-                            const std::size_t aabb_parity =
-                                range_parity(ap0 + 1, ap1) ^ range_parity(bp0 + 1, bp1);
-                            double sign = aabb_parity ? -1.0 : 1.0;
-                            T val = aabb_direct[e.g] * static_cast<T>(sign);
-
-                            if(std::abs(val) > ATOL)
+                            }
+                            if(type2_direct_element(inputs,
+                                                    r0 + row_in_block,
+                                                    row_set_bits,
+                                                    entry.group,
+                                                    col_vec,
+                                                    col_idx,
+                                                    val))
                             {
                                 cols[r0 + row_in_block].push_back(col_idx);
                                 data[r0 + row_in_block].push_back(val);
@@ -558,16 +248,20 @@ void csrlike_builder2(const std::vector<OperatorTerm_t>& terms,
                 }
             }
 
-            // aabb_slow / bbbb / other (group-outer, row-inner).
-            for(const auto& g : aabb_slow_groups)
+            // Direct groups that do not split two and two.
+            for(const auto& g : table.direct_unpaired_groups)
+            {
                 for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-            for(const auto& g : bbbb_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
-            for(const auto& g : other_groups)
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                    process_standard_group(g, row_in_block);
+                {
+                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                    if(type2_direct_element(
+                           inputs, r0 + row_in_block, row_set_bits, g, col_vec, col_idx, val))
+                    {
+                        cols[r0 + row_in_block].push_back(col_idx);
+                        data[r0 + row_in_block].push_back(val);
+                    }
+                }
+            }
         }
     }
 

--- a/fulqrum/core/src/matvec2.hpp
+++ b/fulqrum/core/src/matvec2.hpp
@@ -18,7 +18,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
-#include <unordered_map>
 #include <vector>
 
 #include "external/hash_set8.hpp"
@@ -29,18 +28,12 @@
 #include "constants.hpp"
 #include "elements.hpp"
 #include "offdiag_grouping.hpp"
+#include "type2_group_table.hpp"
 #include <boost/dynamic_bitset.hpp>
 
-// Hermitian sparse matrix-vector product over a subspace Hamiltonian.
-//
-// Each row is owned by a single OpenMP iteration, so out_vec[kk]
-// needs no locking.
-// Group handling mirrors csrlike_builder2: groups are bucketed
-// (aa / aaaa / bb / bbbb / aabb / other) and aabb groups whose
-// terms share a single coeff + real_phase use the direct
-// asign*bsign formula instead of the per-term accum_element loop.
-// other and aabb_slow groups are here for safety.
-// They are supposed to be empty.
+// The group handling mirrors csrlike_builder2. See type2_group_table.hpp for the
+// buckets and for the reason each one is correct. This file holds the row loops
+// and the accumulate action only.
 template <typename T>
 void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
                  const bitset_map_namespace::BitsetHashMapWrapper& subspace,
@@ -61,16 +54,8 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
     const auto* bitsets = subspace.get_bitsets();
 
     // See csrlike_builder2.hpp for the rationale.
-    // The flatten is O(num_groups) and negligible vs the matvec.
-    std::vector<width_t> _flat_inds;
-    std::vector<std::size_t> _inds_offsets;
-    flatten_offdiag_inds(group_offdiag_inds, _flat_inds, _inds_offsets);
-    const width_t* __restrict flat_inds = _flat_inds.data();
-    const std::size_t* __restrict inds_offsets = _inds_offsets.data();
-    auto gview = [&](std::size_t g) -> GroupIndsView {
-        const std::size_t off = inds_offsets[g];
-        return GroupIndsView{flat_inds + off, inds_offsets[g + 1] - off};
-    };
+    const Type2GroupTable table =
+        build_type2_group_table(terms, group_ptrs, group_offdiag_inds, num_groups, width);
 
     // See csrlike_builder2.hpp for the rationale.
     const std::size_t _ladder_len = static_cast<std::size_t>(num_groups) * ladder_offset + 1;
@@ -80,224 +65,60 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
     {
         _ladder32.resize(_ladder_len);
         for(std::size_t i = 0; i < _ladder_len; ++i)
+        {
             _ladder32[i] = static_cast<std::uint32_t>(group_ladder_ptrs[i]);
+        }
     }
-    const std::uint32_t* __restrict ladder32 = _ladder32.data();
-    auto ladder = [&](std::size_t idx) -> std::size_t {
-        return _ladder_fits ? static_cast<std::size_t>(ladder32[idx]) : group_ladder_ptrs[idx];
-    };
 
     std::size_t BLK = 128;
     if(const char* _blk_env = std::getenv("FQ_BLK"))
     {
         long _blk = std::atol(_blk_env);
         if(_blk > 0)
+        {
             BLK = static_cast<std::size_t>(_blk);
+        }
     }
     const std::size_t rsb_w = width; // one uint8 per qubit
     const std::size_t num_blocks = (subspace_dim + BLK - 1) / BLK;
 
-    // Categorize groups into buckets based on offdiag indices (mirror of
-    // csrlike_builder2): aa / aaaa / bb / bbbb / aabb / other.  half_width
-    // splits the bitset into the alpha (lower) and beta (upper) sectors.
-    std::vector<std::size_t> aa_groups;
-    std::vector<std::size_t> aaaa_groups;
-    std::vector<std::size_t> bb_groups;
-    std::vector<std::size_t> bbbb_groups;
-    std::vector<std::size_t> aabb_groups;
-    std::vector<std::size_t> other_groups;
-
-    const width_t half_width = width / 2;
-    for(std::size_t g = 0; g < num_groups; g++)
+    // Flattened shared coefficient of each direct group.
+    std::vector<T> direct_value(num_groups, T(0));
+    for(const auto& group : table.direct_unpaired_groups)
     {
-        const GroupIndsView inds = gview(g);
-        const std::size_t ind_size = inds.size();
-
-        if(ind_size == 2)
+        direct_value[group] = direct_coeff_as<T>(table.direct_coeff[group]);
+    }
+    for(const auto& entries : table.paired_by_low_pair)
+    {
+        for(const auto& entry : entries)
         {
-            if(inds[1] < half_width)
-            {
-                aa_groups.push_back(g);
-            }
-            else if(inds[0] >= half_width)
-            {
-                bb_groups.push_back(g);
-            }
-            else
-            {
-                other_groups.push_back(g);
-            }
-        }
-        else if(ind_size == 4)
-        {
-            if(inds[3] < half_width)
-            {
-                aaaa_groups.push_back(g);
-            }
-            else if(inds[0] >= half_width)
-            {
-                bbbb_groups.push_back(g);
-            }
-            else if(inds[1] < half_width && inds[2] >= half_width)
-            {
-                aabb_groups.push_back(g);
-            }
-            else
-            {
-                other_groups.push_back(g);
-            }
-        }
-        else
-        {
-            other_groups.push_back(g);
+            direct_value[entry.group] = direct_coeff_as<T>(table.direct_coeff[entry.group]);
         }
     }
 
-    // Partition aabb_groups into a fast path (single coeff + real_phase shared
-    // by all terms in the group -> matrix element evaluates as
-    // aabb_direct[g] * asign * bsign) and a slow fallback path that goes
-    // through accum_element per term.
-    std::vector<T> aabb_direct(num_groups, 0);
-    std::vector<std::size_t> aabb_fast_groups;
-    std::vector<std::size_t> aabb_slow_groups;
-    aabb_fast_groups.reserve(aabb_groups.size());
+    const Type2RowInputs<T> inputs{terms,
+                                   subspace,
+                                   table,
+                                   bitsets,
+                                   direct_value.data(),
+                                   group_rowint_length,
+                                   _ladder32.data(),
+                                   group_ladder_ptrs,
+                                   ladder_offset,
+                                   _ladder_fits};
 
-    for(const auto& g : aabb_groups)
+    // Prefilter for the direct paired groups. See type2_prefilter_pairs.
+    emhash8::HashSet<std::uint64_t> low_half_set;
+    emhash8::HashSet<std::uint64_t> high_half_set;
+    if(table.has_paired_groups())
     {
-        std::size_t group_start = group_ptrs[g];
-        std::size_t group_stop = group_ptrs[g + 1];
-
-        if(group_start >= group_stop)
-        {
-            continue; // Empty group, nothing to emit on either path
-        }
-
-        const OperatorTerm_t& first_term = terms[group_start];
-        std::complex<double> group_coeff = first_term.coeff;
-        int group_real_phase = first_term.real_phase;
-
-        bool fast_eligible = true;
-        for(std::size_t i = group_start; i < group_stop; i++)
-        {
-            const OperatorTerm_t& term = terms[i];
-            if(term.real_phase != group_real_phase || std::abs(term.coeff - group_coeff) > 1e-14)
-            {
-                fast_eligible = false;
-                break;
-            }
-        }
-
-        if(fast_eligible)
-        {
-            if constexpr(std::is_same_v<T, double>)
-            {
-                aabb_direct[g] = group_real_phase * group_coeff.real();
-            }
-            else
-            {
-                aabb_direct[g] = static_cast<T>(group_real_phase) * group_coeff;
-            }
-            aabb_fast_groups.push_back(g);
-        }
-        else
-        {
-            aabb_slow_groups.push_back(g);
-        }
-    }
-
-    // aabb fast-path prefilter setup
-    // See csrlike_builder2.hpp for details.
-    auto region_hash = [&](const boost::dynamic_bitset<std::size_t>& bs,
-                           width_t lo,
-                           width_t hi,
-                           width_t fa,
-                           width_t fb) -> std::uint64_t {
-        const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
-        const std::size_t hi_blk = static_cast<std::size_t>(hi - 1) >> BLOCK_EXPONENT;
-        const std::size_t n_blk = hi_blk - lo_blk + 1;
-        static thread_local std::vector<std::size_t> buf;
-        if(buf.size() < n_blk)
-            buf.resize(n_blk);
-        for(std::size_t b = lo_blk; b <= hi_blk; ++b)
-        {
-            std::size_t w = bs.m_bits[b];
-            if(fa != MAX_WIDTH && (fa >> BLOCK_EXPONENT) == b)
-                w ^= (std::size_t(1) << (fa & BLOCK_SHIFT));
-            if(fb != MAX_WIDTH && (fb >> BLOCK_EXPONENT) == b)
-                w ^= (std::size_t(1) << (fb & BLOCK_SHIFT));
-            if(b == lo_blk)
-                w &= (~std::size_t(0) << (lo & BLOCK_SHIFT));
-            if(b == hi_blk)
-            {
-                const std::size_t off = static_cast<std::size_t>(hi - 1) & BLOCK_SHIFT;
-                w &= (off == BLOCK_SHIFT) ? ~std::size_t(0)
-                                          : (~std::size_t(0) >> (BLOCK_SHIFT - off));
-            }
-            buf[b - lo_blk] = w;
-        }
-        return rapidhashMicro(buf.data(), n_blk * sizeof(std::size_t));
-    };
-
-    emhash8::HashSet<std::uint64_t> alpha_half_hashes;
-    emhash8::HashSet<std::uint64_t> beta_half_hashes;
-    std::vector<std::array<width_t, 2>> a_pairs;
-    std::vector<std::array<width_t, 2>> b_pairs;
-    struct AabbEntry
-    {
-        std::uint32_t b_id;
-        std::size_t g;
-    };
-    std::vector<std::vector<AabbEntry>> aabb_by_alpha;
-
-    if(!aabb_fast_groups.empty())
-    {
-        for(std::size_t s = 0; s < subspace_dim; ++s)
+        for(std::size_t s = 0; s < subspace_dim; s++)
         {
             const auto& bs = bitsets[s].first;
-            alpha_half_hashes.insert(region_hash(bs, 0, half_width, MAX_WIDTH, MAX_WIDTH));
-            beta_half_hashes.insert(region_hash(bs, half_width, width, MAX_WIDTH, MAX_WIDTH));
-        }
-
-        std::unordered_map<std::uint32_t, std::uint32_t> a_pair_id;
-        std::unordered_map<std::uint32_t, std::uint32_t> b_pair_id;
-        for(const auto& g : aabb_fast_groups)
-        {
-            const GroupIndsView inds = gview(g);
-            const width_t ap0 = inds[0], ap1 = inds[1], bp0 = inds[2], bp1 = inds[3];
-            const std::uint32_t ak = (std::uint32_t(ap0) << 16) | ap1;
-            const std::uint32_t bk = (std::uint32_t(bp0) << 16) | bp1;
-
-            std::uint32_t a_id;
-            auto ai = a_pair_id.find(ak);
-            if(ai == a_pair_id.end())
-            {
-                a_id = static_cast<std::uint32_t>(a_pairs.size());
-                a_pair_id.emplace(ak, a_id);
-                a_pairs.push_back({ap0, ap1});
-                aabb_by_alpha.emplace_back();
-            }
-            else
-            {
-                a_id = ai->second;
-            }
-
-            std::uint32_t b_id;
-            auto bi = b_pair_id.find(bk);
-            if(bi == b_pair_id.end())
-            {
-                b_id = static_cast<std::uint32_t>(b_pairs.size());
-                b_pair_id.emplace(bk, b_id);
-                b_pairs.push_back({bp0, bp1});
-            }
-            else
-            {
-                b_id = bi->second;
-            }
-            aabb_by_alpha[a_id].push_back({b_id, g});
+            low_half_set.insert(table.half_key(bs, 0, table.split_point));
+            high_half_set.insert(table.half_key(bs, table.split_point, width));
         }
     }
-    const std::size_t num_a_pairs = a_pairs.size();
-    const std::size_t num_b_pairs = b_pairs.size();
 
     // Take care of diagonal term first, if any (usually there is)
     if(has_nonzero_diag)
@@ -317,9 +138,11 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
         {
             // Per-thread scratch, reused across blocks (no per-block realloc).
             std::vector<uint8_t> rsb_buf;
-            std::vector<char> alpha_ok(num_a_pairs);
-            std::vector<char> beta_ok(num_b_pairs);
+            std::vector<char> low_pair_ok(table.low_pairs.size());
+            std::vector<char> high_pair_ok(table.high_pairs.size());
             boost::dynamic_bitset<std::size_t> col_vec;
+            std::size_t col_idx;
+            T val;
 
             // see csrlike_builder2.hpp for details.
 #pragma omp for schedule(dynamic)
@@ -329,209 +152,79 @@ void omp_matvec2(const std::vector<OperatorTerm_t>& terms,
                 const std::size_t r1 = std::min(r0 + BLK, subspace_dim);
                 const std::size_t bn = r1 - r0;
 
-                // row_set_bits for every row in the block, contiguous.
-                rsb_buf.assign(bn * rsb_w, 0);
-                for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
+                fill_block_row_bits(bitsets, r0, bn, rsb_w, rsb_buf);
+
+                // Standard groups (group-outer, row-inner).
+                for(const auto& g : table.standard_groups)
                 {
-                    const boost::dynamic_bitset<std::size_t>& row =
-                        bitsets[r0 + row_in_block].first;
-                    uint8_t* dst = rsb_buf.data() + row_in_block * rsb_w;
-                    for(std::size_t b = 0; b < row.num_blocks(); ++b)
+                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
                     {
-                        std::size_t bits = row.m_bits[b];
-                        while(bits != 0)
+                        const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                        if(type2_standard_element(
+                               inputs, r0 + row_in_block, row_set_bits, g, col_vec, col_idx, val))
                         {
-                            int r = __builtin_ctzll(bits);
-                            dst[b * BITS_PER_BLOCK + r] = 1;
-                            bits &= bits - 1;
+                            out_vec[r0 + row_in_block] += (val * in_vec[col_idx]);
                         }
                     }
                 }
 
-                // Standard per-group path for one (group g, row_in_block) pair.
-                // out_vec[r0+row_in_block] is owned by this block/thread -> no mutex.
-                auto process_standard_group = [&](std::size_t g, std::size_t row_in_block) {
-                    const GroupIndsView group_inds = gview(g);
-                    const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
-
-                    // Hamming weight check.
-                    const width_t _p = group_inds[0];
-                    const width_t _q = group_inds[1];
-                    if(group_inds.size() == 2)
-                    {
-                        if(row_set_bits[_p] == row_set_bits[_q])
-                            return;
-                    }
-                    else if(group_inds.size() == 4)
-                    {
-                        const width_t _r = group_inds[2];
-                        const width_t _s = group_inds[3];
-                        if(row_set_bits[_p] + row_set_bits[_q] + row_set_bits[_r] +
-                               row_set_bits[_s] !=
-                           2)
-                            return;
-                    }
-
-                    const unsigned int row_int =
-                        bitset_ladder_int(row_set_bits, group_inds.data(), group_rowint_length[g]);
-                    const std::size_t group_int_start = ladder(g * ladder_offset + row_int);
-                    const std::size_t group_int_stop = ladder(g * ladder_offset + row_int + 1);
-                    if(group_int_start >= group_int_stop)
-                        return;
-
-                    const boost::dynamic_bitset<std::size_t>& row =
-                        bitsets[r0 + row_in_block].first;
-                    col_vec = row;
-                    flip_bits(col_vec, group_inds.data(), group_inds.size());
-
-                    std::size_t* col_ptr = subspace.get_ptr(col_vec);
-                    if(col_ptr == nullptr)
-                        return;
-                    const std::size_t col_idx = *col_ptr;
-
-                    T val = 0;
-                    for(std::size_t idx = group_int_start; idx < group_int_stop; idx++)
-                    {
-                        const OperatorTerm_t* term = &terms[idx];
-                        if(passes_proj_validation(term, row))
-                        {
-                            accum_element(row,
-                                          col_vec,
-                                          term->indices,
-                                          term->values,
-                                          term->coeff,
-                                          term->real_phase,
-                                          term->indices.size(),
-                                          val);
-                        }
-                    }
-
-                    if(std::abs(val) > ATOL)
-                        out_vec[r0 + row_in_block] += (val * in_vec[col_idx]);
-                };
-
-                for(const auto& g : aa_groups)
-                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                        process_standard_group(g, row_in_block);
-                for(const auto& g : aaaa_groups)
-                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                        process_standard_group(g, row_in_block);
-                for(const auto& g : bb_groups)
-                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                        process_standard_group(g, row_in_block);
-
-                // aabb fast path, ROW-major within the block to preserve the
-                // per-row alpha/beta prefilter skip.
-                if(!aabb_fast_groups.empty())
+                // Direct paired groups.
+                if(table.has_paired_groups())
                 {
                     for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
                     {
                         const boost::dynamic_bitset<std::size_t>& row =
                             bitsets[r0 + row_in_block].first;
                         const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                        type2_prefilter_pairs(table,
+                                              row,
+                                              row_set_bits,
+                                              low_half_set,
+                                              high_half_set,
+                                              width,
+                                              low_pair_ok.data(),
+                                              high_pair_ok.data());
 
-                        auto range_parity = [&](width_t lo, width_t hi) -> std::size_t {
-                            if(lo >= hi)
-                                return 0;
-                            const width_t last = hi - 1; // inclusive last bit
-                            const std::size_t lo_blk = lo >> BLOCK_EXPONENT;
-                            const std::size_t hi_blk =
-                                static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
-                            const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
-                            const std::size_t hi_mask =
-                                ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
-                            std::size_t acc;
-                            if(lo_blk == hi_blk)
-                            {
-                                acc = row.m_bits[lo_blk] & lo_mask & hi_mask;
-                            }
-                            else
-                            {
-                                acc = row.m_bits[lo_blk] & lo_mask;
-                                for(std::size_t b = lo_blk + 1; b < hi_blk; b++)
-                                    acc ^= row.m_bits[b];
-                                acc ^= row.m_bits[hi_blk] & hi_mask;
-                            }
-                            return static_cast<std::size_t>(
-                                __builtin_parityll(static_cast<unsigned long long>(acc)));
-                        };
-
-                        for(std::size_t i = 0; i < num_a_pairs; ++i)
+                        for(std::size_t i = 0; i < table.low_pairs.size(); i++)
                         {
-                            const width_t p0 = a_pairs[i][0];
-                            const width_t p1 = a_pairs[i][1];
-                            if(row_set_bits[p0] == row_set_bits[p1])
+                            if(!low_pair_ok[i])
                             {
-                                alpha_ok[i] = 0;
                                 continue;
                             }
-                            alpha_ok[i] =
-                                alpha_half_hashes.contains(region_hash(row, 0, half_width, p0, p1));
-                        }
-                        for(std::size_t j = 0; j < num_b_pairs; ++j)
-                        {
-                            const width_t p0 = b_pairs[j][0];
-                            const width_t p1 = b_pairs[j][1];
-                            if(row_set_bits[p0] == row_set_bits[p1])
+                            for(const auto& entry : table.paired_by_low_pair[i])
                             {
-                                beta_ok[j] = 0;
-                                continue;
-                            }
-                            beta_ok[j] = beta_half_hashes.contains(
-                                region_hash(row, half_width, width, p0, p1));
-                        }
-
-                        for(std::size_t i = 0; i < num_a_pairs; ++i)
-                        {
-                            if(!alpha_ok[i])
-                                continue;
-                            const width_t ap0 = a_pairs[i][0];
-                            const width_t ap1 = a_pairs[i][1];
-                            for(const auto& e : aabb_by_alpha[i])
-                            {
-                                if(!beta_ok[e.b_id])
+                                if(!high_pair_ok[entry.high_pair_id])
+                                {
                                     continue;
-                                const GroupIndsView group_inds = gview(e.g);
-                                const width_t bp0 = group_inds[2];
-                                const width_t bp1 = group_inds[3];
-
-                                const unsigned int row_int = bitset_ladder_int(
-                                    row_set_bits, group_inds.data(), group_rowint_length[e.g]);
-                                const std::size_t group_int_start =
-                                    ladder(e.g * ladder_offset + row_int);
-                                const std::size_t group_int_stop =
-                                    ladder(e.g * ladder_offset + row_int + 1);
-                                if(group_int_start >= group_int_stop)
-                                    continue;
-
-                                col_vec = row;
-                                flip_bits(col_vec, group_inds.data(), group_inds.size());
-                                std::size_t* col_ptr = subspace.get_ptr(col_vec);
-                                if(col_ptr == nullptr)
-                                    continue;
-                                const std::size_t col_idx = *col_ptr;
-
-                                const std::size_t aabb_parity =
-                                    range_parity(ap0 + 1, ap1) ^ range_parity(bp0 + 1, bp1);
-                                double sign = aabb_parity ? -1.0 : 1.0;
-                                T val = aabb_direct[e.g] * static_cast<T>(sign);
-
-                                if(std::abs(val) > ATOL)
+                                }
+                                if(type2_direct_element(inputs,
+                                                        r0 + row_in_block,
+                                                        row_set_bits,
+                                                        entry.group,
+                                                        col_vec,
+                                                        col_idx,
+                                                        val))
+                                {
                                     out_vec[r0 + row_in_block] += (val * in_vec[col_idx]);
+                                }
                             }
                         }
                     }
                 }
 
-                for(const auto& g : aabb_slow_groups)
+                // Direct groups that do not split two and two.
+                for(const auto& g : table.direct_unpaired_groups)
+                {
                     for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                        process_standard_group(g, row_in_block);
-                for(const auto& g : bbbb_groups)
-                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                        process_standard_group(g, row_in_block);
-                for(const auto& g : other_groups)
-                    for(std::size_t row_in_block = 0; row_in_block < bn; ++row_in_block)
-                        process_standard_group(g, row_in_block);
+                    {
+                        const uint8_t* row_set_bits = rsb_buf.data() + row_in_block * rsb_w;
+                        if(type2_direct_element(
+                               inputs, r0 + row_in_block, row_set_bits, g, col_vec, col_idx, val))
+                        {
+                            out_vec[r0 + row_in_block] += (val * in_vec[col_idx]);
+                        }
+                    }
+                }
             } // end for-loop over blocks
         } // end if num_terms
     } // end parallel region

--- a/fulqrum/core/src/type2_group_table.hpp
+++ b/fulqrum/core/src/type2_group_table.hpp
@@ -1,0 +1,897 @@
+/**
+ * This code is part of Fulqrum.
+ *
+ * (C) Copyright IBM 2026.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+#ifndef BOOST_DYNAMIC_BITSET_DONT_USE_FRIENDS
+#    define BOOST_DYNAMIC_BITSET_DONT_USE_FRIENDS
+#endif
+#pragma once
+// base.hpp brings in bitset_hashmap.hpp, which holds rapidhashMicro. Do not
+// include external/rapidhash.h here, because that header has no include guard.
+#include "base.hpp"
+#include "bitset_utils.hpp"
+#include "constants.hpp"
+#include "elements.hpp"
+#include "offdiag_grouping.hpp"
+#include <algorithm>
+#include <array>
+#include <boost/dynamic_bitset.hpp>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Type-2 group table
+// ---------------------------------------------------------------------------
+//
+// The type-2 paths (csr2.hpp, csrlike_builder2.hpp, matvec2.hpp) sort the
+// off-diagonal groups into three buckets and prepare the tables that the main
+// loops read. This header holds that work, and the three path share it.
+//
+// The buckets come from the operator terms only. No bucket makes an assumption
+// about spin order, about the subspace, or about particle number.
+//
+//   (1) standard groups: Each group goes through ``accum_element`` term by term.
+//   (2) direct groups: Each group is a set of compatible Jordan-Wigner 4-flip terms
+//          with one shared coefficient. Its matrix element is ``coeff * sign``, where
+//          the sign is the parity of the row bits in the two Z-string ranges
+//          (between ladder ops).
+//
+// Direct groups split again into "paired" and "unpaired". A paired group has
+// two flips below ``split_point`` and two flips at or above it. A paired
+// group uses the half-key prefilter for early rejection. The split point is a boundary
+// for the prefilter, not a spin boundary. Any split point gives correct results.
+
+
+inline constexpr std::size_t MAX_PATTERN_FLIPS = 4;
+inline constexpr unsigned int NUM_MAX_FLIP_PATTERNS = 1u << MAX_PATTERN_FLIPS;
+
+/**
+ * Gives the mask that accepts each row pattern of a group.
+ *
+ * @param num_flips The number of flip indices of the group.
+ *
+ * @return A mask with one set bit for each of the 2^num_flips patterns.
+ */
+inline std::uint16_t all_patterns_mask(std::size_t num_flips)
+{
+    if(num_flips > MAX_PATTERN_FLIPS)
+    {
+        num_flips = MAX_PATTERN_FLIPS;
+    }
+    const std::uint32_t num_patterns = std::uint32_t(1) << num_flips;
+    return static_cast<std::uint16_t>((std::uint32_t(1) << num_patterns) - std::uint32_t(1));
+}
+
+/**
+ * Computes the row pattern at the flip indices of a group.
+ *
+ * Example: row = b01011011 (qubit 0 is the rightmost character), flip indices
+ * [0, 1, 4, 5]. The row bits there are 1, 1, 1, 0 (in index order), so pattern =
+ * (1 << 0) | (1 << 1) | (1 << 2) | (0 << 3) = 0b0111 = 7.
+ *
+ * No more than MAX_PATTERN_FLIPS indices are read.
+ *
+ * @param row_set_bits The row bits, one byte per qubit.
+ * @param inds The flip indices of the group.
+ * @param num_inds The number of flip indices.
+ *
+ * @return The row pattern as an unsigned integer.
+ */
+inline unsigned int row_pattern(const uint8_t* __restrict row_set_bits,
+                                const width_t* __restrict inds,
+                                std::size_t num_inds)
+{
+    if(num_inds > MAX_PATTERN_FLIPS)
+    {
+        num_inds = MAX_PATTERN_FLIPS;
+    }
+    unsigned int pattern = 0;
+    for(std::size_t kk = 0; kk < num_inds; kk++)
+    {
+        pattern |= static_cast<unsigned int>(row_set_bits[inds[kk]]) << kk;
+    }
+    return pattern;
+}
+
+/**
+ * Computes the valid row patterns for non-zero element for one term.
+ *
+ * Offdiagonal flip positions can only have +, -, X, and Y as operators. Only row bit=1
+ * is valid pattern for a '+' at a flip index (row bit=0 for a '-'). An X or a Y is a
+ * don't-care: both 0 and 1 row bits are valid for them.
+ *
+ * This term's mask is OR'd into the group's mask. We check the group mask once per row,
+ * and if the actual row bits are a mismatch, we skip element eval for the group.
+ *
+ * @param term The operator term.
+ * @param inds The flip indices of the group, in ascending order.
+ * @param num_inds The number of flip indices.
+ *
+ * @return A mask with one set bit for each accepted row pattern.
+ */
+inline std::uint16_t term_row_pattern_mask(const OperatorTerm_t& term,
+                                           const width_t* __restrict inds,
+                                           const std::size_t num_inds)
+{
+    if(num_inds > MAX_PATTERN_FLIPS)
+    {
+        return all_patterns_mask(num_inds);
+    }
+
+    unsigned int fixed_positions = 0;
+    unsigned int fixed_set_bits = 0;
+    std::size_t num_found = 0;
+
+    std::size_t term_pos = 0;
+    std::size_t flip_pos = 0;
+    const std::size_t term_length = term.indices.size();
+    while(term_pos < term_length && flip_pos < num_inds)
+    {
+        if(term.indices[term_pos] < inds[flip_pos])
+        {
+            term_pos++;
+        }
+        else if(term.indices[term_pos] > inds[flip_pos])
+        {
+            flip_pos++;
+        }
+        else
+        {
+            const unsigned char value = term.values[term_pos];
+            if(value == OPER_VALUE_PLUS)
+            {
+                fixed_positions |= (1u << flip_pos);
+                fixed_set_bits |= (1u << flip_pos);
+            }
+            else if(value == OPER_VALUE_MINUS)
+            {
+                fixed_positions |= (1u << flip_pos);
+            }
+            num_found++;
+            term_pos++;
+            flip_pos++;
+        }
+    }
+
+    // very likely a unreachable case, where
+    // we have flip indices but no operator
+    if(num_found != num_inds)
+    {
+        return all_patterns_mask(num_inds);
+    }
+
+    std::uint16_t mask = 0;
+    const unsigned int num_patterns = 1u << num_inds;
+    for(unsigned int pattern = 0; pattern < num_patterns; pattern++)
+    {
+        if((pattern & fixed_positions) == fixed_set_bits)
+        {
+            mask |= static_cast<std::uint16_t>(1u << pattern);
+        }
+    }
+    return mask;
+}
+
+/**
+ * Tells whether a term is a compatible Jordan-Wigner term on four flip indices.
+ *
+ * A compatible Jordan-Wigner 2-body term only has ladder operator on each flip index
+ * i0 < i1 < i2 < i3 and a Z at each index in the middle ranges (i0, i1) and (i2, i3).
+ * It has no other operator and no projector. Such a term has the matrix element
+ * ``coeff * sign``, where the sign is the parity of the row bits in the two Z ranges.
+ *
+ * @param term The operator term.
+ * @param flips The four flip indices, in ascending order.
+ *
+ * @return True if the term has the compatible Jordan-Wigner structure.
+ */
+inline bool term_is_compat_jw_4flip(const OperatorTerm_t& term, const width_t* __restrict flips)
+{
+    if(!term.proj_indices.empty() || term.offdiag_weight != 4 || term.real_phase != 1)
+    {
+        return false;
+    }
+
+    const width_t first = flips[0];
+    const width_t second = flips[1];
+    const width_t third = flips[2];
+    const width_t fourth = flips[3];
+
+    const std::size_t expected_length = 4 + static_cast<std::size_t>(second - first - 1) +
+                                        static_cast<std::size_t>(fourth - third - 1);
+    if(term.indices.size() != expected_length)
+    {
+        return false;
+    }
+
+    std::size_t pos = 0;
+    const width_t ladder_pair[4] = {first, second, third, fourth};
+    for(std::size_t kk = 0; kk < 4; kk++)
+    {
+        // The Z string that leads up to this ladder operator.
+        if(kk == 1 || kk == 3)
+        {
+            for(width_t idx = ladder_pair[kk - 1] + 1; idx < ladder_pair[kk]; idx++, pos++)
+            {
+                if(term.indices[pos] != idx || term.values[pos] != OPER_VALUE_Z)
+                {
+                    return false;
+                }
+            }
+        }
+        const unsigned char value = term.values[pos];
+        if(term.indices[pos] != ladder_pair[kk] ||
+           (value != OPER_VALUE_PLUS && value != OPER_VALUE_MINUS))
+        {
+            return false;
+        }
+        pos++;
+    }
+    return true;
+}
+
+/**
+ * Computes the parity of the set row bits in the range [lo, hi).
+ *
+ * @param row The row bitset.
+ * @param lo The first bit position of the range.
+ * @param hi The bit position after the range.
+ *
+ * @return 1 if the range holds an odd number of set bits, else 0.
+ */
+inline std::size_t
+range_parity(const boost::dynamic_bitset<std::size_t>& row, const width_t lo, const width_t hi)
+{
+    if(lo >= hi)
+    {
+        return 0;
+    }
+    const width_t last = hi - 1; // inclusive last bit
+    const std::size_t lo_block = lo >> BLOCK_EXPONENT;
+    const std::size_t hi_block = static_cast<std::size_t>(last) >> BLOCK_EXPONENT;
+    const std::size_t lo_mask = ~std::size_t(0) << (lo & BLOCK_SHIFT);
+    const std::size_t hi_mask = ~std::size_t(0) >> (BLOCK_SHIFT - (last & BLOCK_SHIFT));
+    std::size_t acc;
+    if(lo_block == hi_block)
+    {
+        acc = row.m_bits[lo_block] & lo_mask & hi_mask;
+    }
+    else
+    {
+        acc = row.m_bits[lo_block] & lo_mask;
+        for(std::size_t block = lo_block + 1; block < hi_block; block++)
+        {
+            acc ^= row.m_bits[block];
+        }
+        acc ^= row.m_bits[hi_block] & hi_mask;
+    }
+    return static_cast<std::size_t>(__builtin_parityll(static_cast<unsigned long long>(acc)));
+}
+
+/**
+ * Computes the Jordan-Wigner sign of a 4-flip term for a given row.
+ *
+ * @param row The row bitset.
+ * @param flips The four flip indices, in ascending order.
+ *
+ * @return -1.0 or 1.0.
+ */
+inline double jw_4flip_sign(const boost::dynamic_bitset<std::size_t>& row,
+                            const width_t* __restrict flips)
+{
+    const std::size_t parity =
+        range_parity(row, flips[0] + 1, flips[1]) ^ range_parity(row, flips[2] + 1, flips[3]);
+    return parity ? -1.0 : 1.0;
+}
+
+/**
+ * Gives the bits of the range [lo, hi) as one word, with flip_a and flip_b
+ * bits flipped if given.
+ *
+ * We have a pre-filter based on half-bitsets. If a half fits in a single word,
+ * its own bits already are a unique 64-bit identifier, so we use them directly
+ * instead of computing a separate hash to make them 64-bit.
+ *
+ * Use this function only when the range holds no more than BITS_PER_BLOCK bits.
+ * When half does not fit in a word, use half_hash().
+ *
+ * @param bitset The source bitset.
+ * @param lo The first bit position of the range.
+ * @param hi The bit position after the range.
+ * @param flip_a A bit position to flip, or MAX_WIDTH for no flip.
+ * @param flip_b A bit position to flip, or MAX_WIDTH for no flip.
+ *
+ * @return The bits of the range, in the low bits of the result.
+ */
+inline std::uint64_t half_bits(const boost::dynamic_bitset<std::size_t>& bitset,
+                               const width_t lo,
+                               const width_t hi,
+                               const width_t flip_a = MAX_WIDTH,
+                               const width_t flip_b = MAX_WIDTH)
+{
+    const std::size_t lo_block = lo >> BLOCK_EXPONENT;
+    const std::size_t lo_offset = lo & BLOCK_SHIFT;
+    const width_t num_bits = hi - lo;
+
+    std::size_t word = bitset.m_bits[lo_block] >> lo_offset;
+    if(lo_offset != 0 && (lo_block + 1) < bitset.num_blocks())
+    {
+        word |= bitset.m_bits[lo_block + 1] << (BITS_PER_BLOCK - lo_offset);
+    }
+    if(num_bits < BITS_PER_BLOCK)
+    {
+        word &= (std::size_t(1) << num_bits) - std::size_t(1);
+    }
+    if(flip_a != MAX_WIDTH)
+    {
+        word ^= std::size_t(1) << (flip_a - lo);
+    }
+    if(flip_b != MAX_WIDTH)
+    {
+        word ^= std::size_t(1) << (flip_b - lo);
+    }
+    return static_cast<std::uint64_t>(word);
+}
+
+/**
+ * Gives a hash of the bits in the range [lo, hi).
+ *
+ * This is the fallback of ``half_bits`` for a range that is wider than
+ * BITS_PER_BLOCK bits. The parameters have the same meaning. Two different halves
+ * can give the same hash in rare cases, therefore a set of these keys gives false
+ * positives. A false positive costs one subspace look-up and never changes a result.
+ */
+inline std::uint64_t half_hash(const boost::dynamic_bitset<std::size_t>& bitset,
+                               const width_t lo,
+                               const width_t hi,
+                               const width_t flip_a = MAX_WIDTH,
+                               const width_t flip_b = MAX_WIDTH)
+{
+    const std::size_t lo_block = lo >> BLOCK_EXPONENT;
+    const std::size_t hi_block = static_cast<std::size_t>(hi - 1) >> BLOCK_EXPONENT;
+    const std::size_t num_blocks = hi_block - lo_block + 1;
+    static thread_local std::vector<std::size_t> buffer;
+    if(buffer.size() < num_blocks)
+    {
+        buffer.resize(num_blocks);
+    }
+    for(std::size_t block = lo_block; block <= hi_block; block++)
+    {
+        std::size_t word = bitset.m_bits[block];
+        if(flip_a != MAX_WIDTH && (flip_a >> BLOCK_EXPONENT) == block)
+        {
+            word ^= (std::size_t(1) << (flip_a & BLOCK_SHIFT));
+        }
+        if(flip_b != MAX_WIDTH && (flip_b >> BLOCK_EXPONENT) == block)
+        {
+            word ^= (std::size_t(1) << (flip_b & BLOCK_SHIFT));
+        }
+        if(block == lo_block)
+        {
+            word &= (~std::size_t(0) << (lo & BLOCK_SHIFT));
+        }
+        if(block == hi_block)
+        {
+            const std::size_t offset = static_cast<std::size_t>(hi - 1) & BLOCK_SHIFT;
+            word &= (offset == BLOCK_SHIFT) ? ~std::size_t(0)
+                                            : (~std::size_t(0) >> (BLOCK_SHIFT - offset));
+        }
+        buffer[block - lo_block] = word;
+    }
+    return rapidhashMicro(buffer.data(), num_blocks * sizeof(std::size_t));
+}
+
+
+struct PairedDirectGroup
+{
+    std::uint32_t high_pair_id;
+    std::size_t group;
+};
+
+
+struct Type2GroupTable
+{
+    // The flip indices of every group, in one contiguous array.
+    std::vector<width_t> flat_inds;
+    std::vector<std::size_t> inds_offsets;
+
+    std::vector<std::uint16_t> pattern_mask;
+    std::vector<std::complex<double>> direct_coeff;
+
+    // The buckets. Each list holds group numbers in ascending order.
+    // direct_paired_groups is not a flat list like below two.
+    // It is grouped by low pair in paired_by_low_pair.
+    std::vector<std::size_t> standard_groups;
+    std::vector<std::size_t> direct_unpaired_groups;
+
+    // The prefilter boundary.
+    // It splits the bitset into a low half [0, split_point)
+    // and a high half [split_point, width).
+    width_t split_point{0};
+
+    bool half_fits_in_word{true};
+
+    std::vector<std::array<width_t, 2>> low_pairs;
+    std::vector<std::array<width_t, 2>> high_pairs;
+    std::vector<std::uint8_t> low_pair_mask;
+    std::vector<std::uint8_t> high_pair_mask;
+
+    // The direct paired groups, held under the identifier of their low pair.
+    std::vector<std::vector<PairedDirectGroup>> paired_by_low_pair;
+
+    GroupIndsView inds(std::size_t group) const
+    {
+        const std::size_t offset = inds_offsets[group];
+        return GroupIndsView{flat_inds.data() + offset, inds_offsets[group + 1] - offset};
+    }
+
+    bool has_paired_groups() const
+    {
+        return !low_pairs.empty();
+    }
+
+    std::uint64_t half_key(const boost::dynamic_bitset<std::size_t>& bitset,
+                           const width_t lo,
+                           const width_t hi,
+                           const width_t flip_a = MAX_WIDTH,
+                           const width_t flip_b = MAX_WIDTH) const
+    {
+        if(half_fits_in_word)
+        {
+            return half_bits(bitset, lo, hi, flip_a, flip_b);
+        }
+        return half_hash(bitset, lo, hi, flip_a, flip_b);
+    }
+};
+
+/**
+ * Converts the shared coefficient of a direct group into the kernel value type.
+ */
+template <typename T>
+inline T direct_coeff_as(const std::complex<double>& coeff)
+{
+    if constexpr(std::is_same_v<T, double>)
+    {
+        return coeff.real();
+    }
+    else
+    {
+        return static_cast<T>(coeff);
+    }
+}
+
+/**
+ * Sorts the off-diagonal groups into buckets and builds the look-up tables.
+ *
+ * The function reads the operator terms only. It makes no assumption about spin
+ * order, about the subspace, or about particle number.
+ *
+ * @param terms The off-diagonal operator terms, sorted by group.
+ * @param group_ptrs The first term of each group. It has num_groups + 1 entries.
+ * @param group_offdiag_inds The flip indices of each group, in ascending order.
+ * @param num_groups The number of groups.
+ * @param width The operator width.
+ *
+ * @return The table.
+ */
+inline Type2GroupTable
+build_type2_group_table(const std::vector<OperatorTerm_t>& terms,
+                        const std::size_t* __restrict group_ptrs,
+                        const std::vector<std::vector<width_t>>& group_offdiag_inds,
+                        const std::size_t num_groups,
+                        const width_t width)
+{
+    Type2GroupTable table;
+    flatten_offdiag_inds(group_offdiag_inds, table.flat_inds, table.inds_offsets);
+    table.split_point = width / 2;
+    // The low half holds split_point bits and the high half holds the rest.
+    table.half_fits_in_word = (width <= 2 * BITS_PER_BLOCK);
+    table.pattern_mask.assign(num_groups, 0);
+    table.direct_coeff.assign(num_groups, std::complex<double>(0.0, 0.0));
+
+    std::unordered_map<std::uint32_t, std::uint32_t> low_pair_ids;
+    std::unordered_map<std::uint32_t, std::uint32_t> high_pair_ids;
+
+    for(std::size_t group = 0; group < num_groups; group++)
+    {
+        const GroupIndsView inds = table.inds(group);
+        const std::size_t num_flips = inds.size();
+        const std::size_t first_term = group_ptrs[group];
+        const std::size_t stop_term = group_ptrs[group + 1];
+
+        if(first_term >= stop_term)
+        {
+            // An empty group gives no element on any path.
+            table.pattern_mask[group] = 0;
+            continue;
+        }
+
+        // The row patterns that the group accepts.
+        std::uint16_t pattern_mask = 0;
+        bool has_repeat_pattern = false;
+        for(std::size_t idx = first_term; idx < stop_term; idx++)
+        {
+            const std::uint16_t term_mask =
+                term_row_pattern_mask(terms[idx], inds.data(), num_flips);
+            if(pattern_mask & term_mask)
+            {
+                has_repeat_pattern = true;
+            }
+            pattern_mask |= term_mask;
+        }
+        table.pattern_mask[group] = pattern_mask;
+
+        // The direct path needs four compatible Jordan-Wigner flips, one shared
+        // coefficient, and one term per row pattern.
+        bool is_direct = (num_flips == 4) && !has_repeat_pattern;
+        if(is_direct)
+        {
+            const std::complex<double> shared_coeff = terms[first_term].coeff;
+            if(std::abs(shared_coeff) <= ATOL)
+            {
+                is_direct = false;
+            }
+            for(std::size_t idx = first_term; is_direct && idx < stop_term; idx++)
+            {
+                if(!term_is_compat_jw_4flip(terms[idx], inds.data()) ||
+                   std::abs(terms[idx].coeff - shared_coeff) > 1e-14)
+                {
+                    is_direct = false;
+                }
+            }
+            if(is_direct)
+            {
+                table.direct_coeff[group] = shared_coeff;
+            }
+        }
+
+        if(!is_direct)
+        {
+            table.standard_groups.push_back(group);
+            continue;
+        }
+
+        const bool is_paired = (inds[1] < table.split_point) && (inds[2] >= table.split_point);
+        if(!is_paired)
+        {
+            table.direct_unpaired_groups.push_back(group);
+            continue;
+        }
+
+        const width_t low_first = inds[0];
+        const width_t low_second = inds[1];
+        const width_t high_first = inds[2];
+        const width_t high_second = inds[3];
+        const std::uint32_t low_key = (std::uint32_t(low_first) << 16) | low_second;
+        const std::uint32_t high_key = (std::uint32_t(high_first) << 16) | high_second;
+
+        std::uint32_t low_pair_id;
+        auto low_found = low_pair_ids.find(low_key);
+        if(low_found == low_pair_ids.end())
+        {
+            low_pair_id = static_cast<std::uint32_t>(table.low_pairs.size());
+            low_pair_ids.emplace(low_key, low_pair_id);
+            table.low_pairs.push_back({low_first, low_second});
+            table.low_pair_mask.push_back(0);
+            table.paired_by_low_pair.emplace_back();
+        }
+        else
+        {
+            low_pair_id = low_found->second;
+        }
+
+        std::uint32_t high_pair_id;
+        auto high_found = high_pair_ids.find(high_key);
+        if(high_found == high_pair_ids.end())
+        {
+            high_pair_id = static_cast<std::uint32_t>(table.high_pairs.size());
+            high_pair_ids.emplace(high_key, high_pair_id);
+            table.high_pairs.push_back({high_first, high_second});
+            table.high_pair_mask.push_back(0);
+        }
+        else
+        {
+            high_pair_id = high_found->second;
+        }
+
+        // Project the group patterns onto the two pairs. Bits 0 and 1 of a pattern
+        // belong to the low pair, and bits 2 and 3 belong to the high pair.
+        std::uint8_t low_bits = 0;
+        std::uint8_t high_bits = 0;
+        for(unsigned int pattern = 0; pattern < NUM_MAX_FLIP_PATTERNS; pattern++)
+        {
+            if((pattern_mask >> pattern) & 1u)
+            {
+                low_bits |= static_cast<std::uint8_t>(1u << (pattern & 3u));
+                high_bits |= static_cast<std::uint8_t>(1u << ((pattern >> 2) & 3u));
+            }
+        }
+        table.low_pair_mask[low_pair_id] |= low_bits;
+        table.high_pair_mask[high_pair_id] |= high_bits;
+        table.paired_by_low_pair[low_pair_id].push_back({high_pair_id, group});
+    }
+
+    return table;
+}
+
+// ---------------------------------------------------------------------------
+// Row loop helpers
+// ---------------------------------------------------------------------------
+//
+// The three type-2 paths run the same row loops and differ only in what they do
+// with a computed element. These helpers hold the shared work, avoiding duplicate
+// code.
+
+using SubspaceEntry = bitset_map_namespace::BitsetMap::value_type;
+
+template <typename ValueT>
+struct Type2RowInputs
+{
+    const std::vector<OperatorTerm_t>& terms;
+    const bitset_map_namespace::BitsetHashMapWrapper& subspace;
+    const Type2GroupTable& table;
+    const SubspaceEntry* __restrict bitsets;
+    const ValueT* __restrict direct_value;
+    const width_t* __restrict group_rowint_length;
+    const std::uint32_t* __restrict ladder32;
+    const std::size_t* __restrict group_ladder_ptrs;
+    unsigned int ladder_offset;
+    bool ladder_fits;
+
+    // The lean uint32 ladder table when the operator fits it, else the original.
+    std::size_t ladder(std::size_t idx) const
+    {
+        return ladder_fits ? static_cast<std::size_t>(ladder32[idx]) : group_ladder_ptrs[idx];
+    }
+};
+
+/**
+ * @param bitsets The subspace bitsets.
+ * @param first_row The first row of the block.
+ * @param num_rows The number of rows in the block.
+ * @param row_stride The bytes per row.
+ * @param row_bits The output buffer. The function sizes and clears it.
+ */
+inline void fill_block_row_bits(const SubspaceEntry* __restrict bitsets,
+                                const std::size_t first_row,
+                                const std::size_t num_rows,
+                                const std::size_t row_stride,
+                                std::vector<uint8_t>& row_bits)
+{
+    row_bits.assign(num_rows * row_stride, 0);
+    for(std::size_t row_in_block = 0; row_in_block < num_rows; row_in_block++)
+    {
+        const boost::dynamic_bitset<std::size_t>& row = bitsets[first_row + row_in_block].first;
+        uint8_t* dst = row_bits.data() + row_in_block * row_stride;
+        for(std::size_t block = 0; block < row.num_blocks(); block++)
+        {
+            std::size_t bits = row.m_bits[block];
+            while(bits != 0)
+            {
+                const int position = __builtin_ctzll(bits);
+                dst[block * BITS_PER_BLOCK + position] = 1;
+                bits &= bits - 1;
+            }
+        }
+    }
+}
+
+/**
+ * Tells whether some term of a group accepts the row bits at its flip indices.
+ *
+ * @param table The group table.
+ * @param group The group number.
+ * @param group_inds The flip indices of the group.
+ * @param row_set_bits The bits of the row, one byte per qubit.
+ *
+ * @return True when the group can give a non-zero element for this row.
+ */
+inline bool type2_row_pattern_allowed(const Type2GroupTable& table,
+                                      const std::size_t group,
+                                      const GroupIndsView& group_inds,
+                                      const uint8_t* __restrict row_set_bits)
+{
+    const unsigned int pattern = row_pattern(row_set_bits, group_inds.data(), group_inds.size());
+    return ((table.pattern_mask[group] >> pattern) & 1u) != 0;
+}
+
+/**
+ * Builds the candidate column of a group and looks it up in the subspace.
+ *
+ * @param inputs The per-row lookup data shared across groups.
+ * @param group_inds The flip indices of the group.
+ * @param row The row bitset.
+ * @param col_vec Scratch bitset. The function overwrites it with the column.
+ * @param col_idx Output column, valid when the function returns true.
+ *
+ * @return True when the column is in the subspace.
+ */
+template <typename ValueT>
+inline bool type2_lookup_column(const Type2RowInputs<ValueT>& inputs,
+                                const GroupIndsView& group_inds,
+                                const boost::dynamic_bitset<std::size_t>& row,
+                                boost::dynamic_bitset<std::size_t>& col_vec,
+                                std::size_t& col_idx)
+{
+    col_vec = row;
+    flip_bits(col_vec, group_inds.data(), group_inds.size());
+
+    std::size_t* col_ptr = inputs.subspace.get_ptr(col_vec);
+    if(col_ptr == nullptr)
+    {
+        return false;
+    }
+    col_idx = *col_ptr;
+    return true;
+}
+
+/**
+ * Evaluates one standard group for one row.
+ *
+ * ``accum_element`` loops over the terms of the group that the ladder bin selects.
+ *
+ * @param inputs The per-row lookup data shared across groups.
+ * @param row_index The row, as a subspace index.
+ * @param row_set_bits The bits of that row, one byte per qubit.
+ * @param group The group number.
+ * @param col_vec Scratch bitset. The function overwrites it.
+ * @param col_idx Output column, valid when the function returns true.
+ * @param value Output element, valid when the function returns true.
+ *
+ * @return True when the group gives a non-zero element for this row.
+ */
+template <typename ValueT>
+inline bool type2_standard_element(const Type2RowInputs<ValueT>& inputs,
+                                   const std::size_t row_index,
+                                   const uint8_t* __restrict row_set_bits,
+                                   const std::size_t group,
+                                   boost::dynamic_bitset<std::size_t>& col_vec,
+                                   std::size_t& col_idx,
+                                   ValueT& value)
+{
+    const GroupIndsView group_inds = inputs.table.inds(group);
+    if(!type2_row_pattern_allowed(inputs.table, group, group_inds, row_set_bits))
+    {
+        return false;
+    }
+
+    const unsigned int row_int =
+        bitset_ladder_int(row_set_bits, group_inds.data(), inputs.group_rowint_length[group]);
+    const std::size_t first_term = inputs.ladder(group * inputs.ladder_offset + row_int);
+    const std::size_t stop_term = inputs.ladder(group * inputs.ladder_offset + row_int + 1);
+    if(first_term >= stop_term)
+    {
+        return false;
+    }
+
+    const boost::dynamic_bitset<std::size_t>& row = inputs.bitsets[row_index].first;
+    if(!type2_lookup_column(inputs, group_inds, row, col_vec, col_idx))
+    {
+        return false;
+    }
+
+    value = 0;
+    for(std::size_t idx = first_term; idx < stop_term; idx++)
+    {
+        const OperatorTerm_t* term = &inputs.terms[idx];
+        if(passes_proj_validation(term, row))
+        {
+            accum_element(row,
+                          col_vec,
+                          term->indices,
+                          term->values,
+                          term->coeff,
+                          term->real_phase,
+                          term->indices.size(),
+                          value);
+        }
+    }
+    return std::abs(value) > ATOL;
+}
+
+/**
+ * Evaluates one direct group for one row.
+ *
+ * The element is the shared coefficient times the Jordan-Wigner sign, therefore
+ * this path reads neither the ladder table nor the terms. The parameters and the
+ * return value match ``type2_standard_element``.
+ */
+template <typename ValueT>
+inline bool type2_direct_element(const Type2RowInputs<ValueT>& inputs,
+                                 const std::size_t row_index,
+                                 const uint8_t* __restrict row_set_bits,
+                                 const std::size_t group,
+                                 boost::dynamic_bitset<std::size_t>& col_vec,
+                                 std::size_t& col_idx,
+                                 ValueT& value)
+{
+    const GroupIndsView group_inds = inputs.table.inds(group);
+    if(!type2_row_pattern_allowed(inputs.table, group, group_inds, row_set_bits))
+    {
+        return false;
+    }
+
+    const boost::dynamic_bitset<std::size_t>& row = inputs.bitsets[row_index].first;
+    if(!type2_lookup_column(inputs, group_inds, row, col_vec, col_idx))
+    {
+        return false;
+    }
+
+    value = inputs.direct_value[group] * static_cast<ValueT>(jw_4flip_sign(row, group_inds.data()));
+    return std::abs(value) > ATOL;
+}
+
+/**
+ * Marks the flip pairs that can give a column inside the subspace, for one row.
+ *
+ * A direct paired group flips two bits in each half of the bitset, therefore the
+ * low half of a candidate column must equal the low half of some subspace element,
+ * and the high half must equal the high half of some element. Both conditions are
+ * necessary, and they hold per flip pair instead of per group. A failed low pair
+ * then drops each of its groups without a look-up in the subspace hash map.
+ *
+ * @param table The group table.
+ * @param row The row bitset.
+ * @param row_set_bits The bits of that row, one byte per qubit.
+ * @param low_half_set Keys of every low half in the subspace.
+ * @param high_half_set Keys of every high half in the subspace.
+ * @param width The operator width.
+ * @param low_pair_ok Output flags, one per low pair.
+ * @param high_pair_ok Output flags, one per high pair.
+ */
+template <typename HashSetT>
+inline void type2_prefilter_pairs(const Type2GroupTable& table,
+                                  const boost::dynamic_bitset<std::size_t>& row,
+                                  const uint8_t* __restrict row_set_bits,
+                                  const HashSetT& low_half_set,
+                                  const HashSetT& high_half_set,
+                                  const width_t width,
+                                  char* __restrict low_pair_ok,
+                                  char* __restrict high_pair_ok)
+{
+    const width_t split_point = table.split_point;
+
+    for(std::size_t i = 0; i < table.low_pairs.size(); i++)
+    {
+        const width_t first = table.low_pairs[i][0];
+        const width_t second = table.low_pairs[i][1];
+        const unsigned int bits =
+            row_set_bits[first] | (static_cast<unsigned int>(row_set_bits[second]) << 1);
+        if(!((table.low_pair_mask[i] >> bits) & 1u))
+        {
+            low_pair_ok[i] = 0;
+            continue;
+        }
+        low_pair_ok[i] = low_half_set.contains(table.half_key(row, 0, split_point, first, second));
+    }
+
+    for(std::size_t j = 0; j < table.high_pairs.size(); j++)
+    {
+        const width_t first = table.high_pairs[j][0];
+        const width_t second = table.high_pairs[j][1];
+        const unsigned int bits =
+            row_set_bits[first] | (static_cast<unsigned int>(row_set_bits[second]) << 1);
+        if(!((table.high_pair_mask[j] >> bits) & 1u))
+        {
+            high_pair_ok[j] = 0;
+            continue;
+        }
+        high_pair_ok[j] =
+            high_half_set.contains(table.half_key(row, split_point, width, first, second));
+    }
+}

--- a/fulqrum/core/src/type2_group_table.hpp
+++ b/fulqrum/core/src/type2_group_table.hpp
@@ -56,7 +56,6 @@
 // group uses the half-key prefilter for early rejection. The split point is a boundary
 // for the prefilter, not a spin boundary. Any split point gives correct results.
 
-
 inline constexpr std::size_t MAX_PATTERN_FLIPS = 4;
 inline constexpr unsigned int NUM_MAX_FLIP_PATTERNS = 1u << MAX_PATTERN_FLIPS;
 
@@ -396,13 +395,11 @@ inline std::uint64_t half_hash(const boost::dynamic_bitset<std::size_t>& bitset,
     return rapidhashMicro(buffer.data(), num_blocks * sizeof(std::size_t));
 }
 
-
 struct PairedDirectGroup
 {
     std::uint32_t high_pair_id;
     std::size_t group;
 };
-
 
 struct Type2GroupTable
 {

--- a/fulqrum/include/fulqrum.hpp
+++ b/fulqrum/include/fulqrum.hpp
@@ -15,6 +15,4 @@
 
 #include "../core/src/base.hpp"
 #include "../core/src/diag.hpp"
-
-
-
+#include "../core/src/type2_group_table.hpp"

--- a/fulqrum/test/test_type2_spin_order.py
+++ b/fulqrum/test/test_type2_spin_order.py
@@ -1,0 +1,296 @@
+# This code is a part of Fulqrum.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=no-name-in-module
+"""Tests for type-2 groups that carry no alpha and beta order. See Issue # 91"""
+
+import itertools
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import fulqrum as fq
+
+PATH = str(Path(__file__).parent) + "/data/"
+
+LADDER_WIDTHS = [1, 2, 4]
+KERNELS = ["matvec", "csr", "csr_fast"]
+
+DOUBLE_EXCITATION_WIDTH = 28
+DOUBLE_EXCITATION_DETS = [
+    "0000000000000111111111111111",
+    "0000000000011111111111111100",
+]
+
+SYNTHETIC_WIDTH = 6
+
+
+def _double_excitation_operator(coeff=1.0):
+    """Builds the qubit operator of the two-particle group."""
+    fermionic_op = fq.FermionicOperator(
+        DOUBLE_EXCITATION_WIDTH,
+        [
+            ("+-+-", [16, 0, 15, 1], coeff),
+            ("+-+-", [1, 15, 0, 16], np.conj(coeff)),
+        ],
+    )
+    return fermionic_op.extended_jw_transformation()
+
+
+def _reference_matrix(op, subspace):
+    """Builds the dense reference from ``matrix_element``."""
+    strings = []
+    for index in range(len(subspace)):
+        value = subspace.get_n_th_bitstring(index)
+        strings.append(value.decode() if isinstance(value, bytes) else value)
+
+    out = np.zeros((len(strings), len(strings)), dtype=complex)
+    for row, row_str in enumerate(strings):
+        for col, col_str in enumerate(strings):
+            out[row, col] = op.matrix_element(row_str, col_str)
+    return out
+
+
+def _kernel_matrix(hsub, kernel):
+    """Builds the dense matrix of one kernel."""
+    if kernel == "csr":
+        return hsub.to_csr_linearoperator().matrix.toarray()
+    if kernel == "csr_fast":
+        return hsub.to_csr_linearoperator_fast().matrix.toarray()
+    dim = hsub.shape[0]
+    basis = np.eye(dim, dtype=hsub.dtype)
+    return np.column_stack([hsub @ basis[:, idx] for idx in range(dim)])
+
+
+def _check_kernel(op, subspace, kernel, ladder_width, monkeypatch, block_size=None):
+    """Compares one kernel against the ``matrix_element`` reference."""
+    monkeypatch.setenv("FQ_LADDER_WIDTH", str(ladder_width))
+    if block_size is not None:
+        monkeypatch.setenv("FQ_BLK", str(block_size))
+
+    reference = _reference_matrix(op, subspace)
+    hsub = fq.SubspaceHamiltonian(op, subspace)
+    result = _kernel_matrix(hsub, kernel)
+    assert np.allclose(result, reference, atol=1e-12), (
+        f"{kernel} differs from matrix_element at ladder_width={ladder_width}"
+    )
+    return reference
+
+
+def _offdiag_connections(reference):
+    """Counts the non-zero off-diagonal elements of a reference matrix."""
+    off_diagonal = reference - np.diag(np.diag(reference))
+    return int(np.count_nonzero(np.abs(off_diagonal) > 1e-12))
+
+
+def _connected_subspace(op, seed_strings, limit):
+    """Grows a subspace from seed determinants along the group flip indices."""
+    _, off = op.split_diagonal()
+    off.group_sort()
+    group_inds = off.group_offdiag_indices()
+    width = len(seed_strings[0])
+    dets = set(seed_strings)
+    for seed in seed_strings:
+        for indices in group_inds:
+            bits = list(seed)
+            for index in indices:
+                # Bit position 0 is the rightmost character.
+                position = width - 1 - int(index)
+                bits[position] = "0" if bits[position] == "1" else "1"
+            dets.add("".join(bits))
+            if len(dets) >= limit:
+                return sorted(dets)
+    return sorted(dets)
+
+
+def _random_spinless_operator(num_modes, num_terms, seed):
+    """Builds a Hermitian spinless two-body operator with no spin order."""
+    rng = np.random.default_rng(seed)
+    terms = []
+    for _ in range(num_terms):
+        p, q, r, s = (int(x) for x in rng.choice(num_modes, size=4, replace=False))
+        coeff = float(rng.normal())
+        terms.append(("+-+-", [p, q, r, s], coeff))
+        # The Hermitian conjugate of a_p^+ a_q a_r^+ a_s is a_s^+ a_r a_q^+ a_p.
+        terms.append(("+-+-", [s, r, q, p], coeff))
+    return fq.FermionicOperator(num_modes, terms).extended_jw_transformation()
+
+
+@pytest.mark.parametrize("kernel", KERNELS)
+@pytest.mark.parametrize("ladder_width", LADDER_WIDTHS)
+def test_double_excitation_real_coefficient(kernel, ladder_width, monkeypatch):
+    """The two determinants connect, and every kernel finds the element."""
+    op = _double_excitation_operator()
+    subspace = fq.Subspace([list(DOUBLE_EXCITATION_DETS)])
+    reference = _check_kernel(op, subspace, kernel, ladder_width, monkeypatch)
+
+    assert _offdiag_connections(reference) == 2
+
+
+@pytest.mark.parametrize("kernel", KERNELS)
+@pytest.mark.parametrize("ladder_width", LADDER_WIDTHS)
+def test_double_excitation_complex_coefficient(kernel, ladder_width, monkeypatch):
+    op = _double_excitation_operator(coeff=0.5 + 0.25j)
+    subspace = fq.Subspace([list(DOUBLE_EXCITATION_DETS)])
+    reference = _check_kernel(op, subspace, kernel, ladder_width, monkeypatch)
+
+    assert _offdiag_connections(reference) == 2
+
+
+@pytest.mark.parametrize("kernel", KERNELS)
+@pytest.mark.parametrize("ladder_width", LADDER_WIDTHS)
+def test_random_spinless_operator(kernel, ladder_width, monkeypatch):
+    op = _random_spinless_operator(num_modes=12, num_terms=14, seed=7)
+    seeds = ["000111000111", "010101101010", "111000000111"]
+    subspace = fq.Subspace([_connected_subspace(op, seeds, limit=90)])
+    reference = _check_kernel(op, subspace, kernel, ladder_width, monkeypatch)
+    assert _offdiag_connections(reference) > 0
+
+
+@pytest.mark.parametrize("kernel", KERNELS)
+def test_random_spinless_small_block(kernel, monkeypatch):
+    op = _random_spinless_operator(num_modes=12, num_terms=14, seed=7)
+    subspace = fq.Subspace([_connected_subspace(op, ["000111000111"], limit=64)])
+    reference = _check_kernel(op, subspace, kernel, 2, monkeypatch, block_size=3)
+    assert _offdiag_connections(reference) > 0
+
+
+@pytest.mark.parametrize("kernel", KERNELS)
+@pytest.mark.parametrize("ladder_width", LADDER_WIDTHS)
+def test_lih_half_strings(kernel, ladder_width, monkeypatch):
+    """LiH in half-string mode, which has a clean alpha and beta split."""
+    op = fq.FermionicOperator.from_json(PATH + "lih.json").extended_jw_transformation()
+    half_width = op.width // 2
+    halves = []
+    for positions in itertools.combinations(range(half_width), 2):
+        bits = ["0"] * half_width
+        for position in positions:
+            bits[half_width - 1 - position] = "1"
+        halves.append("".join(bits))
+    halves = sorted(halves)[:6]
+
+    subspace = fq.Subspace([list(halves), list(halves)])
+    reference = _check_kernel(op, subspace, kernel, ladder_width, monkeypatch)
+    assert _offdiag_connections(reference) > 0
+
+
+@pytest.mark.parametrize("kernel", KERNELS)
+@pytest.mark.parametrize("ladder_width", LADDER_WIDTHS)
+def test_lih_full_strings(kernel, ladder_width, monkeypatch):
+    """LiH on determinants that carry no alpha and beta order."""
+    op = fq.FermionicOperator.from_json(PATH + "lih.json").extended_jw_transformation()
+    seeds = ["000111000111", "011001100110"]
+    subspace = fq.Subspace([_connected_subspace(op, seeds, limit=70)])
+    reference = _check_kernel(op, subspace, kernel, ladder_width, monkeypatch)
+    assert _offdiag_connections(reference) > 0
+
+
+# Each entry is Hermitian, thus it is a Hamiltonian that fulqrum accepts.
+SYNTHETIC_CASES = [
+    (
+        "paired_double_excitation",
+        [("--++", [0, 1, 4, 5], 1.0), ("++--", [0, 1, 4, 5], 1.0)],
+    ),
+    (
+        "paired_single_excitations",
+        [("+-+-", [0, 1, 4, 5], 1.0), ("-+-+", [0, 1, 4, 5], 1.0)],
+    ),
+    (
+        "unpaired_one_sided",
+        [("++--", [0, 1, 2, 3], 1.0), ("--++", [0, 1, 2, 3], 1.0)],
+    ),
+    (
+        "unpaired_in_complex_operator",
+        [
+            ("++--", [0, 1, 2, 3], 1.0),
+            ("--++", [0, 1, 2, 3], 1.0),
+            ("+-", [4, 5], 0.5 + 0.25j),
+            ("-+", [4, 5], 0.5 - 0.25j),
+        ],
+    ),
+    # Standard. A projector rules the group out of the direct path.
+    (
+        "projector_in_group",
+        [("--++1", [0, 1, 4, 5, 3], 1.0), ("++--1", [0, 1, 4, 5, 3], 1.0)],
+    ),
+    # Standard. The flips at 0, 2, 3 and 5 need a Z at 1 and at 4.
+    (
+        "missing_z_string",
+        [("+-+-", [0, 2, 3, 5], 1.0), ("-+-+", [0, 2, 3, 5], 1.0)],
+    ),
+    # Standard. The flips at 0, 1, 4 and 5 need no Z, so the Z at 2 is extra.
+    (
+        "extra_z_string",
+        [("+-Z+-", [0, 1, 2, 4, 5], 1.0), ("-+Z-+", [0, 1, 2, 4, 5], 1.0)],
+    ),
+    # Standard. Two terms of the group need the same row pattern.
+    (
+        "repeated_term",
+        [
+            ("--++", [0, 1, 4, 5], 1.0),
+            ("--++", [0, 1, 4, 5], 1.0),
+            ("++--", [0, 1, 4, 5], 1.0),
+            ("++--", [0, 1, 4, 5], 1.0),
+        ],
+    ),
+    # Standard. The group holds two different coefficients.
+    (
+        "mixed_coefficients",
+        [
+            ("+-+-", [0, 1, 4, 5], 1.0),
+            ("-+-+", [0, 1, 4, 5], 1.0),
+            ("--++", [0, 1, 4, 5], 0.25),
+            ("++--", [0, 1, 4, 5], 0.25),
+        ],
+    ),
+    # Standard, two flips. Both operators create a particle, therefore the group
+    # does not conserve the particle number.
+    (
+        "non_conserving_two_flip",
+        [("++", [0, 1], 1.0), ("--", [0, 1], 1.0)],
+    ),
+]
+
+
+@pytest.mark.parametrize("kernel", KERNELS)
+@pytest.mark.parametrize(
+    "label,terms", SYNTHETIC_CASES, ids=[c[0] for c in SYNTHETIC_CASES]
+)
+def test_synthetic_type2_operators(kernel, label, terms, monkeypatch):
+    """Synthetic type-2 operators over the full space of six qubits."""
+    op = fq.QubitOperator(SYNTHETIC_WIDTH, terms)
+    op.set_type(2)
+    full_space = fq.Subspace(
+        [[bin(value)[2:].zfill(SYNTHETIC_WIDTH) for value in range(2**SYNTHETIC_WIDTH)]]
+    )
+    reference = _check_kernel(op, full_space, kernel, 2, monkeypatch)
+    assert _offdiag_connections(reference) > 0, label
+
+
+def test_kernels_agree_on_molecular_operator(monkeypatch):
+    monkeypatch.setenv("FQ_LADDER_WIDTH", "2")
+    op = fq.QubitOperator.from_json(PATH + "ch4_dimer_jw.json.xz")
+    dist = fq.utils.io.json_to_dict(PATH + "dimer_subspace.json.xz")
+    subspace = fq.Subspace([list(dist.keys())[:8000]])
+    hsub = fq.SubspaceHamiltonian(op, subspace)
+
+    csr = hsub.to_csr_linearoperator().matrix
+    csr_fast = hsub.to_csr_linearoperator_fast().matrix
+    assert csr.nnz > 0
+    assert csr.nnz == csr_fast.nnz
+    assert np.allclose(csr.indptr, csr_fast.indptr)
+    assert np.allclose(csr.indices, csr_fast.indices)
+    assert np.allclose(csr.data, csr_fast.data)
+
+    rng = np.random.default_rng(3)
+    vector = rng.standard_normal(len(subspace)).astype(hsub.dtype)
+    assert np.allclose(hsub @ vector, csr @ vector, atol=1e-10)

--- a/test/test_type2_table.cpp
+++ b/test/test_type2_table.cpp
@@ -1,0 +1,398 @@
+#include "doctest.h"
+#include "fulqrum.hpp"
+#include <complex>
+#include <string>
+#include <tuple>
+#include <vector>
+
+typedef std::complex<double> complex;
+
+namespace
+{
+
+struct TableFixture
+{
+    QubitOperator off;
+    std::vector<std::size_t> ptrs;
+    std::vector<std::vector<width_t>> group_inds;
+    Type2GroupTable table;
+
+    std::size_t num_groups() const
+    {
+        return ptrs.size() - 1;
+    }
+
+    // Finds the group that has the given flip indices.
+    std::size_t group_of(const std::vector<width_t>& flips) const
+    {
+        for(std::size_t group = 0; group < num_groups(); group++)
+        {
+            if(group_inds[group] == flips)
+            {
+                return group;
+            }
+        }
+        return MAX_SIZE_T;
+    }
+
+    bool is_standard(std::size_t group) const
+    {
+        for(const auto& entry : table.standard_groups)
+        {
+            if(entry == group)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool is_direct_unpaired(std::size_t group) const
+    {
+        for(const auto& entry : table.direct_unpaired_groups)
+        {
+            if(entry == group)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool is_direct_paired(std::size_t group) const
+    {
+        for(const auto& entries : table.paired_by_low_pair)
+        {
+            for(const auto& entry : entries)
+            {
+                if(entry.group == group)
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // Gives the accepted row bits of the low pair that holds the given indices.
+    std::uint8_t low_pair_mask_of(width_t first, width_t second) const
+    {
+        for(std::size_t idx = 0; idx < table.low_pairs.size(); idx++)
+        {
+            if(table.low_pairs[idx][0] == first && table.low_pairs[idx][1] == second)
+            {
+                return table.low_pair_mask[idx];
+            }
+        }
+        return 0;
+    }
+
+    std::uint8_t high_pair_mask_of(width_t first, width_t second) const
+    {
+        for(std::size_t idx = 0; idx < table.high_pairs.size(); idx++)
+        {
+            if(table.high_pairs[idx][0] == first && table.high_pairs[idx][1] == second)
+            {
+                return table.high_pair_mask[idx];
+            }
+        }
+        return 0;
+    }
+};
+
+// Builds the type-2 table of an operator, the same way the type2 paths do.
+TableFixture make_table(width_t width, std::vector<TermData> data, width_t ladder_width = 2)
+{
+    TableFixture fixture;
+    QubitOperator op = QubitOperator(width, data);
+    op.set_type(2);
+    QubitOperator diag;
+    std::tie(diag, fixture.off) = op.split_diagonal();
+    fixture.off.group_sort();
+    fixture.off.group_term_sort_by_ladder_int(ladder_width);
+    fixture.ptrs = fixture.off.group_ptrs();
+    fixture.group_inds = fixture.off.group_offdiag_indices();
+    fixture.table = build_type2_group_table(fixture.off.terms,
+                                            fixture.ptrs.data(),
+                                            fixture.group_inds,
+                                            fixture.ptrs.size() - 1,
+                                            fixture.off.width);
+    return fixture;
+}
+
+constexpr std::uint16_t pattern_bit(unsigned int pattern)
+{
+    return static_cast<std::uint16_t>(1u << pattern);
+}
+
+} // namespace
+
+TEST_CASE("Type-2 table takes a spinless 4-flip group on the direct path")
+{
+    TableFixture fixture = make_table(8,
+                                      {
+                                          {"--++", {0, 1, 6, 7}, 1.0},
+                                          {"++--", {0, 1, 6, 7}, 1.0},
+                                      });
+
+    REQUIRE(fixture.num_groups() == 1);
+    const std::size_t group = fixture.group_of({0, 1, 6, 7});
+    REQUIRE(group != MAX_SIZE_T);
+
+    // Row pattern 0b1100 comes from '-' at 0 and 1 with '+' at 6 and 7.
+    // Row pattern 0b0011 comes from the other term.
+    CHECK(fixture.table.pattern_mask[group] == (pattern_bit(0b1100) | pattern_bit(0b0011)));
+    CHECK(fixture.table.direct_coeff[group] == complex(1.0, 0.0));
+    CHECK(fixture.is_direct_paired(group));
+    CHECK_FALSE(fixture.is_standard(group));
+
+    CHECK(fixture.low_pair_mask_of(0, 1) == 0b1001);
+    CHECK(fixture.high_pair_mask_of(6, 7) == 0b1001);
+}
+
+TEST_CASE("Type-2 table keeps the pair masks of a single-excitation group")
+{
+    TableFixture fixture = make_table(8,
+                                      {
+                                          {"+-+-", {0, 1, 4, 5}, 1.0},
+                                          {"-+-+", {0, 1, 4, 5}, 1.0},
+                                      });
+
+    const std::size_t group = fixture.group_of({0, 1, 4, 5});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.table.pattern_mask[group] == (pattern_bit(0b0101) | pattern_bit(0b1010)));
+    CHECK(fixture.is_direct_paired(group));
+
+    // Each pair accepts unequal row bits only, which is what the older check did.
+    CHECK(fixture.low_pair_mask_of(0, 1) == 0b0110);
+    CHECK(fixture.high_pair_mask_of(4, 5) == 0b0110);
+}
+
+TEST_CASE("Type-2 table accepts a full Jordan-Wigner Z string")
+{
+    // Flips at 0, 2, 5 and 7 need a Z at 1 and a Z at 6.
+    TableFixture fixture = make_table(8, {{"+Z-+Z-", {0, 1, 2, 5, 6, 7}, 1.0}});
+
+    const std::size_t group = fixture.group_of({0, 2, 5, 7});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_direct_paired(group));
+    CHECK(fixture.table.pattern_mask[group] == pattern_bit(0b0101));
+}
+
+TEST_CASE("Type-2 table rejects a 4-flip group with a missing Z")
+{
+    // The same flips as the test above, but with no Z string.
+    TableFixture fixture = make_table(8, {{"+-+-", {0, 2, 5, 7}, 1.0}});
+
+    const std::size_t group = fixture.group_of({0, 2, 5, 7});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_standard(group));
+    // The pattern mask still holds, therefore the standard path keeps its check.
+    CHECK(fixture.table.pattern_mask[group] == pattern_bit(0b0101));
+}
+
+TEST_CASE("Type-2 table rejects a 4-flip group with a Z outside the ranges")
+{
+    // Flips at 0, 3, 5 and 7 need a Z at 1, 2 and 6. This term has the right
+    // number of operators but puts one Z at 4, which is outside both ranges.
+    TableFixture fixture = make_table(8, {{"+ZZ-Z+Z-", {0, 1, 2, 3, 4, 5, 6, 7}, 1.0}});
+
+    const std::size_t group = fixture.group_of({0, 3, 5, 7});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_standard(group));
+}
+
+TEST_CASE("Type-2 table rejects a 4-flip group that holds a projector")
+{
+    TableFixture fixture = make_table(8, {{"--++1", {0, 1, 6, 7, 3}, 1.0}});
+
+    const std::size_t group = fixture.group_of({0, 1, 6, 7});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_standard(group));
+}
+
+TEST_CASE("Type-2 table rejects a 4-flip group that repeats a row pattern")
+{
+    // The same term twice. The direct path would count the pattern once, thus
+    // the group has to stay on the standard path.
+    TableFixture fixture = make_table(8,
+                                      {
+                                          {"--++", {0, 1, 6, 7}, 1.0},
+                                          {"--++", {0, 1, 6, 7}, 1.0},
+                                      });
+
+    const std::size_t group = fixture.group_of({0, 1, 6, 7});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_standard(group));
+}
+
+TEST_CASE("Type-2 table rejects a 4-flip group with two different coefficients")
+{
+    TableFixture fixture = make_table(8,
+                                      {
+                                          {"--++", {0, 1, 6, 7}, 1.0},
+                                          {"++--", {0, 1, 6, 7}, 0.5},
+                                      });
+
+    const std::size_t group = fixture.group_of({0, 1, 6, 7});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_standard(group));
+}
+
+TEST_CASE("Type-2 table puts a one-sided 4-flip group on the unpaired direct path")
+{
+    // Each flip sits below the split point, therefore the group cannot use the
+    // half-key prefilter. It still evaluates with the direct formula.
+    TableFixture fixture = make_table(8, {{"++--", {0, 1, 2, 3}, 1.0}});
+
+    const std::size_t group = fixture.group_of({0, 1, 2, 3});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_direct_unpaired(group));
+    CHECK_FALSE(fixture.table.has_paired_groups());
+    CHECK(fixture.table.pattern_mask[group] == pattern_bit(0b0011));
+}
+
+TEST_CASE("Type-2 table keeps a 2-flip group that does not conserve particles")
+{
+    // Both operators create a particle. The older Hamming weight check dropped
+    // every row of this group, because it accepted unequal row bits only.
+    TableFixture fixture = make_table(4, {{"++", {0, 1}, 1.0}});
+
+    const std::size_t group = fixture.group_of({0, 1});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_standard(group));
+    CHECK(fixture.table.pattern_mask[group] == pattern_bit(0b11));
+}
+
+TEST_CASE("Type-2 table accepts every row pattern of a wide group")
+{
+    // The table tracks patterns for up to four flips.
+    // A wider group gets a mask that accepts everything.
+    TableFixture fixture = make_table(8, {{"++----", {0, 1, 2, 3, 4, 5}, 1.0}});
+
+    const std::size_t group = fixture.group_of({0, 1, 2, 3, 4, 5});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_standard(group));
+    CHECK(fixture.table.pattern_mask[group] == 0xFFFF);
+}
+
+TEST_CASE("Type-2 table marks an X operator as a don't care row bit")
+{
+    // An X accepts both 0 and 1 row bits at its flip, therefore the group accepts two
+    // patterns. Such a group never reaches the direct path.
+    TableFixture fixture = make_table(4, {{"X-", {0, 1}, 1.0}});
+
+    const std::size_t group = fixture.group_of({0, 1});
+    REQUIRE(group != MAX_SIZE_T);
+    CHECK(fixture.is_standard(group));
+    CHECK(fixture.table.pattern_mask[group] == (pattern_bit(0b00) | pattern_bit(0b01)));
+}
+
+TEST_CASE("Type-2 table chooses the exact half key for a narrow operator")
+{
+    TableFixture narrow = make_table(8, {{"--++", {0, 1, 6, 7}, 1.0}});
+    CHECK(narrow.table.half_fits_in_word);
+    CHECK(narrow.table.split_point == 4);
+}
+
+TEST_CASE("Half key reads the requested bit range")
+{
+    boost::dynamic_bitset<std::size_t> bits(8);
+    bits[0] = 1;
+    bits[3] = 1;
+    bits[5] = 1;
+
+    CHECK(half_bits(bits, 0, 4) == 0b1001);
+    CHECK(half_bits(bits, 4, 8) == 0b0010);
+    // Flip bit 0 and bit 3 of the low half.
+    CHECK(half_bits(bits, 0, 4, 0, 3) == 0b0000);
+    // A flip and a hash of the same half agree with themselves.
+    CHECK(half_hash(bits, 0, 4) == half_hash(bits, 0, 4));
+    CHECK(half_hash(bits, 0, 4, 0, 3) != half_hash(bits, 0, 4));
+}
+
+TEST_CASE("Range parity counts the set bits between two flips")
+{
+    boost::dynamic_bitset<std::size_t> bits(8);
+    bits[2] = 1;
+    bits[4] = 1;
+
+    CHECK(range_parity(bits, 0, 8) == 0); // two set bits
+    CHECK(range_parity(bits, 0, 3) == 1); // one set bit
+    CHECK(range_parity(bits, 3, 3) == 0); // empty range
+
+    // Flips at 1 and 6 enclose both set bits, therefore the sign is positive.
+    const width_t flips[4] = {1, 6, 6, 7};
+    CHECK(jw_4flip_sign(bits, flips) == 1.0);
+    const width_t odd_flips[4] = {1, 3, 6, 7};
+    CHECK(jw_4flip_sign(bits, odd_flips) == -1.0);
+}
+
+TEST_CASE("Direct groups of a molecular operator hold only ladder operators and Z")
+{
+    // The direct path evaluates an element as coeff * sign, where the sign is the
+    // parity of the row bits in the two Jordan-Wigner Z ranges. That formula holds
+    // only for a term that has a ladder operator at each flip, a Z at each index
+    // inside the two ranges, and nothing else. This test reads real data and confirms
+    // the property, instead of only confirming that synthetic bad groups get rejected.
+    //
+    // The path is relative, therefore run the test binary from the repository root.
+    FermionicOperator fop = FermionicOperator::from_json("test/data/lih.json");
+    QubitOperator op = fop.extended_jw_transformation();
+    QubitOperator diag, off;
+    std::tie(diag, off) = op.split_diagonal();
+    off.group_sort();
+    off.group_term_sort_by_ladder_int(2);
+
+    std::vector<std::size_t> ptrs = off.group_ptrs();
+    std::vector<std::vector<width_t>> group_inds = off.group_offdiag_indices();
+    const std::size_t num_groups = ptrs.size() - 1;
+    Type2GroupTable table =
+        build_type2_group_table(off.terms, ptrs.data(), group_inds, num_groups, off.width);
+
+    std::vector<std::size_t> direct = table.direct_unpaired_groups;
+    for(const auto& entries : table.paired_by_low_pair)
+    {
+        for(const auto& entry : entries)
+        {
+            direct.push_back(entry.group);
+        }
+    }
+    REQUIRE(direct.size() > 0);
+
+    std::size_t terms_checked = 0;
+    for(const std::size_t group : direct)
+    {
+        const GroupIndsView inds = table.inds(group);
+        REQUIRE(inds.size() == 4);
+        for(std::size_t idx = ptrs[group]; idx < ptrs[group + 1]; idx++)
+        {
+            const OperatorTerm_t& term = off.terms[idx];
+            terms_checked++;
+            CHECK(term.proj_indices.empty());
+            CHECK(term.offdiag_weight == 4);
+            CHECK(term.real_phase == 1);
+            for(std::size_t k = 0; k < term.indices.size(); k++)
+            {
+                const width_t position = term.indices[k];
+                const unsigned char value = term.values[k];
+                const bool is_flip = (position == inds[0] || position == inds[1] ||
+                                      position == inds[2] || position == inds[3]);
+                if(is_flip)
+                {
+                    CHECK((value == OPER_VALUE_PLUS || value == OPER_VALUE_MINUS));
+                }
+                else
+                {
+                    // Every other operator is a Z, and it sits inside one of the two
+                    // ranges that the sign formula reads.
+                    CHECK(value == OPER_VALUE_Z);
+                    const bool in_range = (position > inds[0] && position < inds[1]) ||
+                                          (position > inds[2] && position < inds[3]);
+                    CHECK(in_range);
+                }
+            }
+        }
+    }
+    CHECK(terms_checked > 0);
+}


### PR DESCRIPTION
Fixes #91.

 1. Dropped categorizing groups into aa/bb/aaaa/bbbb/aabb buckets because the bucketing is restrictive and incorrect for spinless systems. Also, we do not impose any spin-ordering of alpha and beta orbitals for full-strs subspace mode.
 2. Now, the groups are categorized into two buckets: direct groups (which follow direct matrix element evaluation formula) and standard groups (all others that use `accum_element()`). Direct groups are further divided into paired and unpaired.
    - Direct paired: we split a bitset in an arbitrary middle point (width/2). If two flip positions are in one half and other two in the other half (two-and-two), we qualify the group as direct paired. We have a half-bitset-based prefiltering for these groups: if the low half does not exist in the subspace, we skip evaluation for the group. The split does not assume any spin ordering and only enables the pre-filtering.
    - Direct unpaired: Groups that do not have the two-and-two split. Does not use the pre-filtering. Uses the subspace hashmap lookup and direct formula for matrix element evaluation.
3. The direct vs. standard groups categorization is based solely on the operator terms. There are several checks to prevent the bug like #91. Also, spin ordering assumptions are removed. 
4. Type2 paths (csr2.hpp, csrlike_builder2.hpp, and matvec2.hpp) used same loops duplicated three times in three files to evaluate a matrix element. Only the final write destination differed. The common loops are moved to a single place inside `typ2_group_table.hpp` to avoid duplication.