### PR TITLE
Fix type1 `csr.hpp` symmetric write race

### DIFF
--- a/fulqrum/__init__.py
+++ b/fulqrum/__init__.py
@@ -12,7 +12,7 @@
 
 """Fulqrum"""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 
 from .core import (

--- a/fulqrum/core/src/csr.hpp
+++ b/fulqrum/core/src/csr.hpp
@@ -161,9 +161,6 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
                     if(col_ptr == nullptr)
                         continue;
                     const std::size_t col_idx = *col_ptr;
-                    T row_nnz_col_idx, elem_start_col_idx;
-                    T& row_nnz = row_nnz_s[kk];
-                    T& elem_start = indptr[kk];
                     U val = 0;
                     for(std::size_t idx = group_start; idx < group_stop; idx++)
                     { // begin loop over terms in this group
@@ -184,36 +181,21 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
                     {
                         if(compute_values)
                         {
-#pragma omp atomic write
+                            // To prevent write contention 
+                            T row_nnz;
+#pragma omp atomic capture
+                            row_nnz = row_nnz_s[kk]++;
+                            const T elem_start = indptr[kk];
                             indices[elem_start + row_nnz] = col_idx;
-                            if constexpr(std::is_same_v<U, double>) // real case
-                            {
-#pragma omp atomic write
-                                data[elem_start + row_nnz] = val;
-                            }
-                            else // imaginary case
-                            {
-                                double* __restrict p =
-                                    reinterpret_cast<double*>(&data[elem_start + row_nnz]);
-                                const double* __restrict q = reinterpret_cast<const double*>(&val);
-#pragma omp atomic
-                                p[0] += q[0]; // real part
-#pragma omp atomic
-                                p[1] += q[1]; // imag part
-                            }
-#pragma omp atomic
-                            row_nnz += 1;
+                            data[elem_start + row_nnz] = val;
 
-                            row_nnz_col_idx = row_nnz_s[col_idx];
-                            elem_start_col_idx = indptr[col_idx];
-#pragma omp atomic write
+                            T row_nnz_col_idx;
+#pragma omp atomic capture
+                            row_nnz_col_idx = row_nnz_s[col_idx]++;
+                            const T elem_start_col_idx = indptr[col_idx];
                             indices[elem_start_col_idx + row_nnz_col_idx] = kk;
-#pragma omp atomic
-                            row_nnz_s[col_idx] += 1;
-                            // process col_idx
                             if constexpr(std::is_same_v<U, double>)
                             {
-#pragma omp atomic write
                                 data[elem_start_col_idx + row_nnz_col_idx] = val;
                             }
                             else
@@ -221,21 +203,13 @@ void csr_matrix_builder(const std::vector<OperatorTerm_t>& terms,
                                 // for complex-valued matrix, the upper triangle
                                 // element will be complex conjugate of the lower
                                 // triangle element
-                                const U update_val = std::conj(val);
-                                double* __restrict p2 = reinterpret_cast<double*>(
-                                    &data[elem_start_col_idx + row_nnz_col_idx]);
-                                const double* __restrict q2 =
-                                    reinterpret_cast<const double*>(&update_val);
-#pragma omp atomic write
-                                p2[0] = q2[0]; // real part
-#pragma omp atomic write
-                                p2[1] = q2[1]; // imag part
+                                data[elem_start_col_idx + row_nnz_col_idx] = std::conj(val);
                             }
                         }
                         else
                         {
 #pragma omp atomic
-                            row_nnz += 1;
+                            row_nnz_s[kk] += 1;
 
 #pragma omp atomic
                             row_nnz_s[col_idx] += 1;

--- a/fulqrum/core/src/csrlike_builder.hpp
+++ b/fulqrum/core/src/csrlike_builder.hpp
@@ -178,8 +178,7 @@ void csrlike_builder(const std::vector<OperatorTerm_t>& terms,
                     }
                     if(std::abs(val) > ATOL)
                     {
-                        // see fulqrum/core/src/csr.hpp for details
-                        // about these Mutex locks
+                        // Mutex locks to prevent symmetric write contention
                         {
                             std::lock_guard<std::mutex> lock_kk(mutex1[kk].m);
                             cols[kk].push_back(col_idx);

--- a/fulqrum/core/src/version.hpp
+++ b/fulqrum/core/src/version.hpp
@@ -13,5 +13,5 @@
  */
 #pragma once
 
-#define FULQRUM_VERSION "0.4.1"
+#define FULQRUM_VERSION "0.4.2"
 #define JSON_VERSION "1.1"

--- a/fulqrum/test/test_csr.py
+++ b/fulqrum/test/test_csr.py
@@ -366,3 +366,27 @@ def test_csr_nnz_LiH():
     Hsub = fq.SubspaceHamiltonian(op, S)
     A = Hsub.to_csr_linearoperator()
     assert A.nnz == 102400
+
+
+def test_csr_parallel_hermitian_fill(monkeypatch):
+    """Ensure parallel Hermitian inserts write to unique CSR positions."""
+    width = 13
+    dim = 1 << width
+    monkeypatch.setenv("FQ_BLK", "1")
+
+    op = fq.QubitOperator(width)
+    for qubit in range(width):
+        label = "I" * qubit + "X" + "I" * (width - qubit - 1)
+        op += fq.QubitOperator.from_label(label, qubit + 1.0)
+    op += fq.QubitOperator.from_label("Z" * width, 0.25)
+    op.set_type(1)
+
+    strings = [format(value, f"0{width}b") for value in range(dim)]
+    subspace = fq.Subspace([strings])
+    hsub = fq.SubspaceHamiltonian(op, subspace)
+    matrix = hsub.to_csr_linearoperator().matrix
+
+    vector = np.random.default_rng(7).standard_normal(dim)
+    assert np.all(np.diff(matrix.indptr) == width + 1)
+    assert np.allclose(matrix @ vector, hsub @ vector)
+    assert (matrix != matrix.T).nnz == 0


### PR DESCRIPTION
`csr.hpp` had a symmetric write race. The phase-1 CSR structure/counting pass identified correct number of non-zero elements (nnzs). However, phase-2 CSR fill pass had an issue where different parallel threads were writing/over-writing into same slots, leading to incorrect nnzs which is different than the phase-1 counting.

This PR fixes the issue. Verified on Fe4S4. A new test is added to capture it next time.  