### PR TITLE
Fix Fulqrum image link so that it renders on pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
-![fulqrum_logo](./docs/images/fulqrum_logo.png)
-
+![](https://raw.githubusercontent.com/qiskit-community/fulqrum/main/docs/images/fulqrum_logo.png)
 
 # Fulqrum
 


### PR DESCRIPTION
The Fulqrum image in the readme does not render on the pypi website.  This should fix that.